### PR TITLE
A compat wrapper that converts `TransactionInstruction` to `IInstruction`

### DIFF
--- a/packages/compat/package.json
+++ b/packages/compat/package.json
@@ -75,7 +75,8 @@
         "@solana/codecs-core": "workspace:*",
         "@solana/errors": "workspace:*",
         "@solana/keys": "workspace:*",
-        "@solana/transactions": "workspace:*"
+        "@solana/transactions": "workspace:*",
+        "@solana/instructions": "workspace:*"
     },
     "devDependencies": {
         "@solana/keys": "workspace:*",

--- a/packages/compat/package.json
+++ b/packages/compat/package.json
@@ -74,9 +74,9 @@
         "@solana/addresses": "workspace:*",
         "@solana/codecs-core": "workspace:*",
         "@solana/errors": "workspace:*",
+        "@solana/instructions": "workspace:*",
         "@solana/keys": "workspace:*",
-        "@solana/transactions": "workspace:*",
-        "@solana/instructions": "workspace:*"
+        "@solana/transactions": "workspace:*"
     },
     "devDependencies": {
         "@solana/keys": "workspace:*",

--- a/packages/compat/src/__tests__/instruction-test.ts
+++ b/packages/compat/src/__tests__/instruction-test.ts
@@ -25,14 +25,14 @@ describe('fromLegacyTransactionInstruction', () => {
 
         const converted = fromLegacyTransactionInstruction(instruction);
 
-        expect(converted).toMatchObject<IInstruction>({
+        expect(converted).toStrictEqual<IInstruction>({
             accounts: [
                 {
                     address: address('7EqQdEULxWcraVx3mXKFjc84LhCkMGZCkRuDpvcMwJeK'),
                     role: AccountRole.WRITABLE,
                 },
             ],
-            data: Buffer.from(data),
+            data,
             programAddress: fromLegacyPublicKey(new PublicKey(programId)),
         });
     });
@@ -50,7 +50,7 @@ describe('fromLegacyTransactionInstruction', () => {
         const converted = fromLegacyTransactionInstruction(instruction);
 
         expect(converted).toStrictEqual<IInstruction>({
-            data: Buffer.from(data),
+            data,
             programAddress: fromLegacyPublicKey(new PublicKey(programId)),
         });
     });
@@ -75,7 +75,7 @@ describe('fromLegacyTransactionInstruction', () => {
 
         const converted = fromLegacyTransactionInstruction(instruction);
 
-        expect(converted).toMatchObject<IInstruction>({
+        expect(converted).toStrictEqual<IInstruction>({
             accounts: [
                 {
                     address: address('7EqQdEULxWcraVx3mXKFjc84LhCkMGZCkRuDpvcMwJeK'),
@@ -86,7 +86,7 @@ describe('fromLegacyTransactionInstruction', () => {
                     role: AccountRole.READONLY,
                 },
             ],
-            data: Buffer.from(data),
+            data,
             programAddress: fromLegacyPublicKey(new PublicKey(programId)),
         });
     });

--- a/packages/compat/src/__tests__/instruction-test.ts
+++ b/packages/compat/src/__tests__/instruction-test.ts
@@ -1,0 +1,124 @@
+import { address } from '@solana/addresses';
+import { AccountRole, IInstruction } from '@solana/instructions';
+import { PublicKey, TransactionInstruction } from '@solana/web3.js';
+
+import { fromLegacyPublicKey } from '../address';
+import { fromLegacyTransactionInstruction } from '../instruction';
+
+describe('fromLegacyTransactionInstruction', () => {
+    it('converts a basic TransactionInstruction', () => {
+        const programId = new Uint8Array([1, 2, 3, 4]);
+        const keys = [
+            {
+                isSigner: false,
+                isWritable: true,
+                pubkey: new PublicKey('7EqQdEULxWcraVx3mXKFjc84LhCkMGZCkRuDpvcMwJeK'),
+            },
+        ];
+        const data = new Uint8Array([10, 20, 30]);
+
+        const instruction = new TransactionInstruction({
+            data: Buffer.from(data),
+            keys,
+            programId: new PublicKey(programId),
+        });
+
+        const converted = fromLegacyTransactionInstruction(instruction);
+
+        expect(converted).toMatchObject<IInstruction>({
+            accounts: [
+                {
+                    address: address('7EqQdEULxWcraVx3mXKFjc84LhCkMGZCkRuDpvcMwJeK'),
+                    role: AccountRole.WRITABLE,
+                },
+            ],
+            data: Buffer.from(data),
+            programAddress: fromLegacyPublicKey(new PublicKey(programId)),
+        });
+    });
+
+    it('handles an instruction with no keys', () => {
+        const programId = new Uint8Array([5, 6, 7, 8]);
+        const data = new Uint8Array([40, 50, 60]);
+
+        const instruction = new TransactionInstruction({
+            data: Buffer.from(data),
+            keys: [],
+            programId: new PublicKey(programId),
+        });
+
+        const converted = fromLegacyTransactionInstruction(instruction);
+
+        expect(converted).toMatchObject<IInstruction>({
+            accounts: [],
+            data: Buffer.from(data),
+            programAddress: fromLegacyPublicKey(new PublicKey(programId)),
+        });
+    });
+
+    it('handles an instruction with multiple keys', () => {
+        const programId = new Uint8Array([9, 10, 11, 12]);
+        const keys = [
+            { isSigner: true, isWritable: true, pubkey: new PublicKey('7EqQdEULxWcraVx3mXKFjc84LhCkMGZCkRuDpvcMwJeK') },
+            {
+                isSigner: false,
+                isWritable: false,
+                pubkey: new PublicKey('9A87Qt8sxxLMe7hcrjC4cPnho1CwWKRpk84ZTRPyvWNw'),
+            },
+        ];
+        const data = new Uint8Array([70, 80, 90]);
+
+        const instruction = new TransactionInstruction({
+            data: Buffer.from(data),
+            keys,
+            programId: new PublicKey(programId),
+        });
+
+        const converted = fromLegacyTransactionInstruction(instruction);
+
+        expect(converted).toMatchObject<IInstruction>({
+            accounts: [
+                {
+                    address: address('7EqQdEULxWcraVx3mXKFjc84LhCkMGZCkRuDpvcMwJeK'),
+                    role: AccountRole.WRITABLE_SIGNER,
+                },
+                {
+                    address: address('9A87Qt8sxxLMe7hcrjC4cPnho1CwWKRpk84ZTRPyvWNw'),
+                    role: AccountRole.READONLY,
+                },
+            ],
+            data: Buffer.from(data),
+            programAddress: fromLegacyPublicKey(new PublicKey(programId)),
+        });
+    });
+
+    it('handles an empty data field gracefully', () => {
+        const programId = new Uint8Array([13, 14, 15, 16]);
+        const keys = [
+            {
+                isSigner: true,
+                isWritable: false,
+                pubkey: new PublicKey('F7Kzv7G6p1PvHXL1xXLPTm4myKWpLjnVphCV8ABZJfgT'),
+            },
+        ];
+
+        const instruction = new TransactionInstruction({
+            data: Buffer.from(new Uint8Array()),
+            keys,
+            programId: new PublicKey(programId),
+        });
+
+        const converted = fromLegacyTransactionInstruction(instruction);
+
+        expect(converted).toMatchObject<IInstruction>({
+            accounts: [
+                {
+                    address: address('F7Kzv7G6p1PvHXL1xXLPTm4myKWpLjnVphCV8ABZJfgT'),
+                    role: AccountRole.READONLY_SIGNER,
+                },
+            ],
+            data: Buffer.from([]),
+            programAddress: fromLegacyPublicKey(new PublicKey(programId)),
+        });
+    });
+});

--- a/packages/compat/src/__tests__/instruction-test.ts
+++ b/packages/compat/src/__tests__/instruction-test.ts
@@ -37,7 +37,7 @@ describe('fromLegacyTransactionInstruction', () => {
         });
     });
 
-    it('handles an instruction with no keys', () => {
+    it('applies no acccounts given an instruction with no keys', () => {
         const programId = new Uint8Array([5, 6, 7, 8]);
         const data = new Uint8Array([40, 50, 60]);
 
@@ -49,8 +49,7 @@ describe('fromLegacyTransactionInstruction', () => {
 
         const converted = fromLegacyTransactionInstruction(instruction);
 
-        expect(converted).toMatchObject<IInstruction>({
-            accounts: [],
+        expect(converted).toStrictEqual<IInstruction>({
             data: Buffer.from(data),
             programAddress: fromLegacyPublicKey(new PublicKey(programId)),
         });

--- a/packages/compat/src/__tests__/instruction-test.ts
+++ b/packages/compat/src/__tests__/instruction-test.ts
@@ -1,3 +1,5 @@
+import '@solana/test-matchers/toBeFrozenObject';
+
 import { address } from '@solana/addresses';
 import { AccountRole, IInstruction } from '@solana/instructions';
 import { PublicKey, TransactionInstruction } from '@solana/web3.js';
@@ -35,6 +37,72 @@ describe('fromLegacyTransactionInstruction', () => {
             data,
             programAddress: fromLegacyPublicKey(new PublicKey(programId)),
         });
+    });
+
+    it('freezes the accounts array', () => {
+        const programId = new Uint8Array([1, 2, 3, 4]);
+        const keys = [
+            {
+                isSigner: false,
+                isWritable: true,
+                pubkey: new PublicKey('7EqQdEULxWcraVx3mXKFjc84LhCkMGZCkRuDpvcMwJeK'),
+            },
+        ];
+        const data = new Uint8Array([10, 20, 30]);
+
+        const instruction = new TransactionInstruction({
+            data: Buffer.from(data),
+            keys,
+            programId: new PublicKey(programId),
+        });
+
+        const converted = fromLegacyTransactionInstruction(instruction);
+
+        expect(converted.accounts).toBeFrozenObject();
+    });
+
+    it('freezes each account', () => {
+        const programId = new Uint8Array([1, 2, 3, 4]);
+        const keys = [
+            {
+                isSigner: false,
+                isWritable: true,
+                pubkey: new PublicKey('7EqQdEULxWcraVx3mXKFjc84LhCkMGZCkRuDpvcMwJeK'),
+            },
+        ];
+        const data = new Uint8Array([10, 20, 30]);
+
+        const instruction = new TransactionInstruction({
+            data: Buffer.from(data),
+            keys,
+            programId: new PublicKey(programId),
+        });
+
+        const converted = fromLegacyTransactionInstruction(instruction);
+
+        expect(converted.accounts?.[0]).toBeFrozenObject();
+    });
+
+    it('freezes the instruction', () => {
+        const programId = new Uint8Array([1, 2, 3, 4]);
+        const keys = [
+            {
+                isSigner: false,
+                isWritable: true,
+                pubkey: new PublicKey('7EqQdEULxWcraVx3mXKFjc84LhCkMGZCkRuDpvcMwJeK'),
+            },
+        ];
+        const data = new Uint8Array([10, 20, 30]);
+
+        const instruction = new TransactionInstruction({
+            data: Buffer.from(data),
+            keys,
+            programId: new PublicKey(programId),
+        });
+
+        const converted = fromLegacyTransactionInstruction(instruction);
+
+        expect(converted).toBeFrozenObject();
     });
 
     it('applies no acccounts given an instruction with no keys', () => {

--- a/packages/compat/src/__tests__/instruction-test.ts
+++ b/packages/compat/src/__tests__/instruction-test.ts
@@ -92,7 +92,7 @@ describe('fromLegacyTransactionInstruction', () => {
         });
     });
 
-    it('handles an empty data field gracefully', () => {
+    it('applies no data field if the data is zero-length', () => {
         const programId = new Uint8Array([13, 14, 15, 16]);
         const keys = [
             {
@@ -110,14 +110,41 @@ describe('fromLegacyTransactionInstruction', () => {
 
         const converted = fromLegacyTransactionInstruction(instruction);
 
-        expect(converted).toMatchObject<IInstruction>({
+        expect(converted).toStrictEqual<IInstruction>({
             accounts: [
                 {
                     address: address('F7Kzv7G6p1PvHXL1xXLPTm4myKWpLjnVphCV8ABZJfgT'),
                     role: AccountRole.READONLY_SIGNER,
                 },
             ],
-            data: Buffer.from([]),
+            programAddress: fromLegacyPublicKey(new PublicKey(programId)),
+        });
+    });
+
+    it('applies no data field if the data is missing', () => {
+        const programId = new Uint8Array([13, 14, 15, 16]);
+        const keys = [
+            {
+                isSigner: true,
+                isWritable: false,
+                pubkey: new PublicKey('F7Kzv7G6p1PvHXL1xXLPTm4myKWpLjnVphCV8ABZJfgT'),
+            },
+        ];
+
+        const instruction = new TransactionInstruction({
+            keys,
+            programId: new PublicKey(programId),
+        });
+
+        const converted = fromLegacyTransactionInstruction(instruction);
+
+        expect(converted).toStrictEqual<IInstruction>({
+            accounts: [
+                {
+                    address: address('F7Kzv7G6p1PvHXL1xXLPTm4myKWpLjnVphCV8ABZJfgT'),
+                    role: AccountRole.READONLY_SIGNER,
+                },
+            ],
             programAddress: fromLegacyPublicKey(new PublicKey(programId)),
         });
     });

--- a/packages/compat/src/__tests__/instruction-test.ts
+++ b/packages/compat/src/__tests__/instruction-test.ts
@@ -147,4 +147,32 @@ describe('fromLegacyTransactionInstruction', () => {
             programAddress: fromLegacyPublicKey(new PublicKey(programId)),
         });
     });
+
+    it.each`
+        isSigner | isWritable | expected
+        ${false} | ${false}   | ${AccountRole.READONLY}
+        ${false} | ${true}    | ${AccountRole.WRITABLE}
+        ${true}  | ${false}   | ${AccountRole.READONLY_SIGNER}
+        ${true}  | ${true}    | ${AccountRole.WRITABLE_SIGNER}
+    `(
+        'converts keys with isSigner: $isSigner, isWritable: $isWritable to $expected',
+        ({
+            isSigner,
+            isWritable,
+            expected,
+        }: {
+            expected: keyof typeof AccountRole;
+            isSigner: boolean;
+            isWritable: boolean;
+        }) => {
+            expect(
+                fromLegacyTransactionInstruction(
+                    new TransactionInstruction({
+                        keys: [{ isSigner, isWritable, pubkey: PublicKey.default }],
+                        programId: PublicKey.default,
+                    }),
+                ),
+            ).toHaveProperty('accounts', expect.arrayContaining([expect.objectContaining({ role: expected })]));
+        },
+    );
 });

--- a/packages/compat/src/__typetests__/instruction-typetests.ts.ts
+++ b/packages/compat/src/__typetests__/instruction-typetests.ts.ts
@@ -3,8 +3,6 @@ import { TransactionInstruction } from '@solana/web3.js';
 
 import { fromLegacyTransactionInstruction } from '../instruction';
 
-// Mock legacy TransactionInstruction
 const legacyInstruction = null as unknown as TransactionInstruction;
 
-// Ensure that the output of fromLegacyTransactionInstruction satisfies the IInstruction type
 fromLegacyTransactionInstruction(legacyInstruction) satisfies IInstruction;

--- a/packages/compat/src/__typetests__/instruction-typetests.ts.ts
+++ b/packages/compat/src/__typetests__/instruction-typetests.ts.ts
@@ -1,0 +1,10 @@
+import { IInstruction } from '@solana/instructions/src';
+import { TransactionInstruction } from '@solana/web3.js';
+
+import { fromLegacyTransactionInstruction } from '../instruction';
+
+// Mock legacy TransactionInstruction
+const legacyInstruction = null as unknown as TransactionInstruction;
+
+// Ensure that the output of fromLegacyTransactionInstruction satisfies the IInstruction type
+fromLegacyTransactionInstruction(legacyInstruction) satisfies IInstruction;

--- a/packages/compat/src/__typetests__/instruction-typetests.ts.ts
+++ b/packages/compat/src/__typetests__/instruction-typetests.ts.ts
@@ -1,4 +1,4 @@
-import { IInstruction } from '@solana/instructions/src';
+import { IInstruction } from '@solana/instructions';
 import { TransactionInstruction } from '@solana/web3.js';
 
 import { fromLegacyTransactionInstruction } from '../instruction';

--- a/packages/compat/src/index.ts
+++ b/packages/compat/src/index.ts
@@ -1,3 +1,4 @@
 export * from './address';
+export * from './instruction';
 export * from './keypair';
 export * from './transaction';

--- a/packages/compat/src/instruction.ts
+++ b/packages/compat/src/instruction.ts
@@ -11,7 +11,7 @@ export function fromLegacyTransactionInstruction(legacyInstruction: TransactionI
     }));
     const programAddress = fromLegacyPublicKey(legacyInstruction.programId);
     return {
-        accounts,
+        ...(accounts.length ? { accounts } : null),
         ...(data ? { data } : null),
         programAddress,
     };

--- a/packages/compat/src/instruction.ts
+++ b/packages/compat/src/instruction.ts
@@ -5,9 +5,9 @@ import { fromLegacyPublicKey } from './address';
 
 export function fromLegacyTransactionInstruction(legacyInstruction: TransactionInstruction): IInstruction {
     const data = legacyInstruction.data ? Uint8Array.from(legacyInstruction.data) : undefined;
-    const accounts = legacyInstruction.keys.map(key => ({
-        address: fromLegacyPublicKey(key.pubkey),
-        role: determineRole(key.isSigner, key.isWritable),
+    const accounts = legacyInstruction.keys.map(accountMeta => ({
+        address: fromLegacyPublicKey(accountMeta.pubkey),
+        role: determineRole(accountMeta.isSigner, accountMeta.isWritable),
     }));
     const programAddress = fromLegacyPublicKey(legacyInstruction.programId);
     return {

--- a/packages/compat/src/instruction.ts
+++ b/packages/compat/src/instruction.ts
@@ -1,0 +1,32 @@
+import { AccountRole, IInstruction } from '@solana/instructions/src';
+import { TransactionInstruction } from '@solana/web3.js';
+
+import { fromLegacyPublicKey } from './address';
+
+export function fromLegacyTransactionInstruction(legacyInstruction: TransactionInstruction): IInstruction {
+    // Map data (Buffer -> Uint8Array)
+    const data = legacyInstruction.data ? Uint8Array.from(legacyInstruction.data) : undefined;
+
+    // Map keys (pubkey -> address, isSigner/isWritable -> role)
+    const accounts = legacyInstruction.keys.map(key => ({
+        address: fromLegacyPublicKey(key.pubkey), // Convert PublicKey to string
+        role: determineRole(key.isSigner, key.isWritable), // Map role
+    }));
+
+    // Map programId (PublicKey -> Address)
+    const programAddress = fromLegacyPublicKey(legacyInstruction.programId);
+
+    return {
+        accounts,
+        data,
+        programAddress,
+    };
+}
+
+// Helper function to determine the role
+function determineRole(isSigner: boolean, isWritable: boolean): AccountRole {
+    if (isSigner && isWritable) return AccountRole.WRITABLE_SIGNER;
+    if (isSigner) return AccountRole.READONLY_SIGNER;
+    if (isWritable) return AccountRole.WRITABLE;
+    return AccountRole.READONLY;
+}

--- a/packages/compat/src/instruction.ts
+++ b/packages/compat/src/instruction.ts
@@ -4,18 +4,12 @@ import { TransactionInstruction } from '@solana/web3.js';
 import { fromLegacyPublicKey } from './address';
 
 export function fromLegacyTransactionInstruction(legacyInstruction: TransactionInstruction): IInstruction {
-    // Map data (Buffer -> Uint8Array)
     const data = legacyInstruction.data ? Uint8Array.from(legacyInstruction.data) : undefined;
-
-    // Map keys (pubkey -> address, isSigner/isWritable -> role)
     const accounts = legacyInstruction.keys.map(key => ({
-        address: fromLegacyPublicKey(key.pubkey), // Convert PublicKey to string
-        role: determineRole(key.isSigner, key.isWritable), // Map role
+        address: fromLegacyPublicKey(key.pubkey),
+        role: determineRole(key.isSigner, key.isWritable),
     }));
-
-    // Map programId (PublicKey -> Address)
     const programAddress = fromLegacyPublicKey(legacyInstruction.programId);
-
     return {
         accounts,
         data,
@@ -23,7 +17,6 @@ export function fromLegacyTransactionInstruction(legacyInstruction: TransactionI
     };
 }
 
-// Helper function to determine the role
 function determineRole(isSigner: boolean, isWritable: boolean): AccountRole {
     if (isSigner && isWritable) return AccountRole.WRITABLE_SIGNER;
     if (isSigner) return AccountRole.READONLY_SIGNER;

--- a/packages/compat/src/instruction.ts
+++ b/packages/compat/src/instruction.ts
@@ -5,16 +5,18 @@ import { fromLegacyPublicKey } from './address';
 
 export function fromLegacyTransactionInstruction(legacyInstruction: TransactionInstruction): IInstruction {
     const data = legacyInstruction.data?.byteLength > 0 ? Uint8Array.from(legacyInstruction.data) : undefined;
-    const accounts = legacyInstruction.keys.map(accountMeta => ({
-        address: fromLegacyPublicKey(accountMeta.pubkey),
-        role: determineRole(accountMeta.isSigner, accountMeta.isWritable),
-    }));
+    const accounts = legacyInstruction.keys.map(accountMeta =>
+        Object.freeze({
+            address: fromLegacyPublicKey(accountMeta.pubkey),
+            role: determineRole(accountMeta.isSigner, accountMeta.isWritable),
+        }),
+    );
     const programAddress = fromLegacyPublicKey(legacyInstruction.programId);
-    return {
-        ...(accounts.length ? { accounts } : null),
+    return Object.freeze({
+        ...(accounts.length ? { accounts: Object.freeze(accounts) } : null),
         ...(data ? { data } : null),
         programAddress,
-    };
+    });
 }
 
 function determineRole(isSigner: boolean, isWritable: boolean): AccountRole {

--- a/packages/compat/src/instruction.ts
+++ b/packages/compat/src/instruction.ts
@@ -4,7 +4,7 @@ import { TransactionInstruction } from '@solana/web3.js';
 import { fromLegacyPublicKey } from './address';
 
 export function fromLegacyTransactionInstruction(legacyInstruction: TransactionInstruction): IInstruction {
-    const data = legacyInstruction.data ? Uint8Array.from(legacyInstruction.data) : undefined;
+    const data = legacyInstruction.data?.byteLength > 0 ? Uint8Array.from(legacyInstruction.data) : undefined;
     const accounts = legacyInstruction.keys.map(accountMeta => ({
         address: fromLegacyPublicKey(accountMeta.pubkey),
         role: determineRole(accountMeta.isSigner, accountMeta.isWritable),
@@ -12,7 +12,7 @@ export function fromLegacyTransactionInstruction(legacyInstruction: TransactionI
     const programAddress = fromLegacyPublicKey(legacyInstruction.programId);
     return {
         accounts,
-        data,
+        ...(data ? { data } : null),
         programAddress,
     };
 }

--- a/packages/compat/src/instruction.ts
+++ b/packages/compat/src/instruction.ts
@@ -1,4 +1,4 @@
-import { AccountRole, IInstruction } from '@solana/instructions/src';
+import { AccountRole, IInstruction } from '@solana/instructions';
 import { TransactionInstruction } from '@solana/web3.js';
 
 import { fromLegacyPublicKey } from './address';

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -38,7 +38,7 @@ importers:
         version: link:packages/build-scripts
       '@solana/eslint-config-solana':
         specifier: ^4.0.0
-        version: 4.0.0(@eslint/js@9.16.0)(@types/eslint__js@8.42.3)(eslint-plugin-jest@28.9.0(@typescript-eslint/eslint-plugin@8.17.0(@typescript-eslint/parser@8.17.0(eslint@9.16.0(jiti@1.21.0))(typescript@5.7.2))(eslint@9.16.0(jiti@1.21.0))(typescript@5.7.2))(eslint@9.16.0(jiti@1.21.0))(jest@30.0.0-alpha.6(@types/node@22.10.2)(ts-node@10.9.2(@swc/core@1.7.26(@swc/helpers@0.5.11))(@types/node@22.10.2)(typescript@5.7.2)))(typescript@5.7.2))(eslint-plugin-react-hooks@5.1.0(eslint@9.16.0(jiti@1.21.0)))(eslint-plugin-simple-import-sort@12.1.1(eslint@9.16.0(jiti@1.21.0)))(eslint-plugin-sort-keys-fix@1.1.2)(eslint-plugin-typescript-sort-keys@3.3.0(@typescript-eslint/parser@8.17.0(eslint@9.16.0(jiti@1.21.0))(typescript@5.7.2))(eslint@9.16.0(jiti@1.21.0))(typescript@5.7.2))(eslint@9.16.0(jiti@1.21.0))(globals@15.13.0)(jest@30.0.0-alpha.6(@types/node@22.10.2)(ts-node@10.9.2(@swc/core@1.7.26(@swc/helpers@0.5.11))(@types/node@22.10.2)(typescript@5.7.2)))(typescript-eslint@8.17.0(eslint@9.16.0(jiti@1.21.0))(typescript@5.7.2))(typescript@5.7.2)
+        version: 4.0.0(ziy5kb23c57ogti67tr2maysrm)
       '@solana/prettier-config-solana':
         specifier: 0.0.5
         version: 0.0.5(prettier@3.4.2)
@@ -463,6 +463,9 @@ importers:
       '@solana/errors':
         specifier: workspace:*
         version: link:../errors
+      '@solana/instructions':
+        specifier: workspace:*
+        version: link:../instructions
       '@solana/keys':
         specifier: workspace:*
         version: link:../keys
@@ -9571,8 +9574,8 @@ snapshots:
     dependencies:
       buffer: 6.0.3
 
-  ? '@solana/eslint-config-solana@4.0.0(@eslint/js@9.16.0)(@types/eslint__js@8.42.3)(eslint-plugin-jest@28.9.0(@typescript-eslint/eslint-plugin@8.17.0(@typescript-eslint/parser@8.17.0(eslint@9.16.0(jiti@1.21.0))(typescript@5.7.2))(eslint@9.16.0(jiti@1.21.0))(typescript@5.7.2))(eslint@9.16.0(jiti@1.21.0))(jest@30.0.0-alpha.6(@types/node@22.10.2)(ts-node@10.9.2(@swc/core@1.7.26(@swc/helpers@0.5.11))(@types/node@22.10.2)(typescript@5.7.2)))(typescript@5.7.2))(eslint-plugin-react-hooks@5.1.0(eslint@9.16.0(jiti@1.21.0)))(eslint-plugin-simple-import-sort@12.1.1(eslint@9.16.0(jiti@1.21.0)))(eslint-plugin-sort-keys-fix@1.1.2)(eslint-plugin-typescript-sort-keys@3.3.0(@typescript-eslint/parser@8.17.0(eslint@9.16.0(jiti@1.21.0))(typescript@5.7.2))(eslint@9.16.0(jiti@1.21.0))(typescript@5.7.2))(eslint@9.16.0(jiti@1.21.0))(globals@15.13.0)(jest@30.0.0-alpha.6(@types/node@22.10.2)(ts-node@10.9.2(@swc/core@1.7.26(@swc/helpers@0.5.11))(@types/node@22.10.2)(typescript@5.7.2)))(typescript-eslint@8.17.0(eslint@9.16.0(jiti@1.21.0))(typescript@5.7.2))(typescript@5.7.2)'
-  : dependencies:
+  '@solana/eslint-config-solana@4.0.0(ziy5kb23c57ogti67tr2maysrm)':
+    dependencies:
       '@eslint/js': 9.16.0
       '@types/eslint__js': 8.42.3
       eslint: 9.16.0(jiti@1.21.0)


### PR DESCRIPTION
solves https://github.com/anza-xyz/solana-web3.js/issues/10