### PR TITLE
Enable eslint rule and reject with errors instead of strings

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -14,7 +14,7 @@ export default [
             '@typescript-eslint/no-unsafe-member-access': 'off',
             '@typescript-eslint/no-unsafe-return': 'off',
             '@typescript-eslint/only-throw-error': 'off',
-            '@typescript-eslint/prefer-promise-reject-errors': 'off',
+            '@typescript-eslint/prefer-promise-reject-errors': 'error',
             '@typescript-eslint/restrict-plus-operands': 'error',
             '@typescript-eslint/restrict-template-expressions': 'error',
             '@typescript-eslint/unbound-method': 'off',

--- a/examples/rpc-transport-throttled/src/example.ts
+++ b/examples/rpc-transport-throttled/src/example.ts
@@ -94,7 +94,8 @@ function getThrottledTransport<TClusterUrl extends ClusterUrl>(
             } as QueuedRequest<TClusterUrl>);
             if (config.signal) {
                 config.signal.addEventListener('abort', function () {
-                    reject(new Error(this.reason));
+                    // eslint-disable-next-line @typescript-eslint/prefer-promise-reject-errors
+                    reject(this.reason);
                 });
             }
             processQueue();

--- a/examples/rpc-transport-throttled/src/example.ts
+++ b/examples/rpc-transport-throttled/src/example.ts
@@ -94,7 +94,7 @@ function getThrottledTransport<TClusterUrl extends ClusterUrl>(
             } as QueuedRequest<TClusterUrl>);
             if (config.signal) {
                 config.signal.addEventListener('abort', function () {
-                    reject(this.reason);
+                    reject(new Error(this.reason));
                 });
             }
             processQueue();

--- a/packages/promises/src/abortable.ts
+++ b/packages/promises/src/abortable.ts
@@ -10,9 +10,11 @@ export function getAbortablePromise<T>(promise: Promise<T>, abortSignal?: AbortS
             // want to throw even if the input promise's result is ready
             new Promise<never>((_, reject) => {
                 if (abortSignal.aborted) {
+                    // eslint-disable-next-line @typescript-eslint/prefer-promise-reject-errors
                     reject(abortSignal.reason);
                 } else {
                     abortSignal.addEventListener('abort', function () {
+                        // eslint-disable-next-line @typescript-eslint/prefer-promise-reject-errors
                         reject(this.reason);
                     });
                 }

--- a/packages/rpc-subscriptions-channel-websocket/src/websocket-channel.ts
+++ b/packages/rpc-subscriptions-channel-websocket/src/websocket-channel.ts
@@ -25,6 +25,7 @@ export function createWebSocketChannel({
     url,
 }: Config): Promise<RpcSubscriptionsChannel<WebSocketMessage, string>> {
     if (signal.aborted) {
+        // eslint-disable-next-line @typescript-eslint/prefer-promise-reject-errors
         return Promise.reject(signal.reason);
     }
     let bufferDrainWatcher: Readonly<{ onCancel(): void; promise: Promise<void> }> | undefined;

--- a/packages/rpc-subscriptions-spec/src/rpc-subscriptions-pubsub-plan.ts
+++ b/packages/rpc-subscriptions-spec/src/rpc-subscriptions-pubsub-plan.ts
@@ -135,6 +135,7 @@ export async function executeRpcPubSubSubscriptionPlan<TNotification>({
                 subscriptionId = undefined;
                 channel.send(unsubscribePayload).catch(() => {});
             }
+            // eslint-disable-next-line @typescript-eslint/prefer-promise-reject-errors
             reject(this.reason);
         }
         if (signal.aborted) {

--- a/packages/rpc/src/__tests__/rpc-request-coalescer-test.ts
+++ b/packages/rpc/src/__tests__/rpc-request-coalescer-test.ts
@@ -110,7 +110,8 @@ describe('RPC request coalescer', () => {
                     return await new Promise((resolve, reject) => {
                         transportResponsePromise = resolve;
                         signal?.addEventListener('abort', (e: AbortSignalEventMap['abort']) => {
-                            reject(new Error((e.target as AbortSignal).reason));
+                            // eslint-disable-next-line @typescript-eslint/prefer-promise-reject-errors
+                            reject((e.target as AbortSignal).reason);
                         });
                     });
                 });

--- a/packages/rpc/src/__tests__/rpc-request-coalescer-test.ts
+++ b/packages/rpc/src/__tests__/rpc-request-coalescer-test.ts
@@ -110,7 +110,7 @@ describe('RPC request coalescer', () => {
                     return await new Promise((resolve, reject) => {
                         transportResponsePromise = resolve;
                         signal?.addEventListener('abort', (e: AbortSignalEventMap['abort']) => {
-                            reject((e.target as AbortSignal).reason);
+                            reject(new Error((e.target as AbortSignal).reason));
                         });
                     });
                 });

--- a/packages/rpc/src/rpc-request-coalescer.ts
+++ b/packages/rpc/src/rpc-request-coalescer.ts
@@ -84,6 +84,7 @@ export function getRpcTransportWithRequestCoalescing<TTransport extends RpcTrans
                             abortController.abort((EXPLICIT_ABORT_TOKEN ||= createExplicitAbortToken()));
                         }
                     });
+                    // eslint-disable-next-line @typescript-eslint/prefer-promise-reject-errors
                     reject((e.target as AbortSignal).reason);
                 };
                 signal.addEventListener('abort', handleAbort);


### PR DESCRIPTION
Following #13 , this PR intends to enable the eslint rule: `prefer-promise-reject-errors` as error.

I believe that treating promise rejections as errors ensures better handling and propagation of the rejection reason to the final components. The affected package tests have been updated accordingly.
