### PR TITLE
Remove deep import in waiters.ts

### DIFF
--- a/packages/transaction-confirmation/src/__tests__/waiters-test.ts
+++ b/packages/transaction-confirmation/src/__tests__/waiters-test.ts
@@ -4,11 +4,12 @@ import { SOLANA_ERROR__TRANSACTION__FEE_PAYER_SIGNATURE_MISSING, SolanaError } f
 import { Signature, SignatureBytes } from '@solana/keys';
 import type { Blockhash } from '@solana/rpc-types';
 import { Nonce } from '@solana/transaction-messages';
-import { Transaction, TransactionMessageBytes } from '@solana/transactions';
 import {
+    Transaction,
+    TransactionMessageBytes,
     TransactionWithBlockhashLifetime,
     TransactionWithDurableNonceLifetime,
-} from '@solana/transactions/dist/types/lifetime';
+} from '@solana/transactions';
 
 import {
     waitForDurableNonceTransactionConfirmation,

--- a/packages/transaction-confirmation/src/waiters.ts
+++ b/packages/transaction-confirmation/src/waiters.ts
@@ -1,9 +1,10 @@
 import { Signature } from '@solana/keys';
-import { getSignatureFromTransaction, Transaction } from '@solana/transactions';
 import {
+    getSignatureFromTransaction,
+    Transaction,
     TransactionWithBlockhashLifetime,
     TransactionWithDurableNonceLifetime,
-} from '@solana/transactions/dist/types/lifetime';
+} from '@solana/transactions';
 
 import { createBlockHeightExceedencePromiseFactory } from './confirmation-strategy-blockheight';
 import { createNonceInvalidationPromiseFactory } from './confirmation-strategy-nonce';


### PR DESCRIPTION
This PR fixes a deep import that broke my app with the following error message:

```
node_modules/.pnpm/@solana+transaction-confirmation@2.0.0_fastestsmallesttextencoderdecoder@1.0.22_typescript@5.7.2_ws@8.18.0/node_modules/@solana/transaction-confirmation/dist/types/waiters.d.ts:3:87 - error TS2307: Cannot find module '@solana/transactions/dist/types/lifetime' or its corresponding type declarations.

3 import { TransactionWithBlockhashLifetime, TransactionWithDurableNonceLifetime } from '@solana/transactions/dist/types/lifetime';
```