### PR TITLE
update `compat` readme to include instructions

### DIFF
--- a/.changeset/rotten-dryers-fix.md
+++ b/.changeset/rotten-dryers-fix.md
@@ -1,0 +1,5 @@
+---
+'@solana/compat': patch
+---
+
+updated readme to include instruction compat functions

--- a/packages/compat/README.md
+++ b/packages/compat/README.md
@@ -33,7 +33,7 @@ import { fromLegacyKeypair } from '@solana/compat';
 const { privateKey, publicKey } = await fromLegacyKeypair(Keypair.generate());
 ```
 
-### `fromVersionedTransaction`
+### `fromVersionedTransaction()`
 
 This can be used to convert a legacy `VersionedTransaction` object to a `Transaction` object.
 
@@ -43,4 +43,16 @@ import { fromVersionedTransaction } from '@solana/compat';
 // imagine a function that returns a legacy `VersionedTransaction`
 const legacyVersionedTransaction = getMyLegacyVersionedTransaction();
 const transaction = fromVersionedTransaction(legacyVersionedTransaction);
+```
+
+### `fromLegacyTransactionInstruction()`
+
+This can be used to convert a legacy `TransactionInstruction` object to a `IInstruction` object.
+
+```ts
+import { fromLegacyTransactionInstruction } from '@solana/compat';
+
+// imagine a function that returns a legacy `TransactionInstruction`
+const legacyInstruction = getMyLegacyInstruction();
+const transaction = fromLegacyTransactionInstruction(legacyVersionedTransaction);
 ```

--- a/packages/compat/README.md
+++ b/packages/compat/README.md
@@ -54,5 +54,5 @@ import { fromLegacyTransactionInstruction } from '@solana/compat';
 
 // imagine a function that returns a legacy `TransactionInstruction`
 const legacyInstruction = getMyLegacyInstruction();
-const transaction = fromLegacyTransactionInstruction(legacyVersionedTransaction);
+const instruction = fromLegacyTransactionInstruction(legacyInstruction);
 ```


### PR DESCRIPTION
## Overview

The readme for the [@solana/compat](https://www.npmjs.com/package/@solana/compat) is missing documentation for the [instruction](https://github.com/anza-xyz/solana-web3.js/blob/main/packages/compat/src/instruction.ts) related compat functions

## Changes

- added `fromLegacyTransactionInstruction` to readme
- updated headings to be consistent

Fixes: #56 