### PR TITLE
The Ed25519 polyfill now accepts the full range of algorithm identifiers for the `Ed25519` curve

### DIFF
--- a/.changeset/ninety-islands-compete.md
+++ b/.changeset/ninety-islands-compete.md
@@ -1,0 +1,5 @@
+---
+'@solana/webcrypto-ed25519-polyfill': patch
+---
+
+Fixed a bug where specifying `Ed25519` in a different case, or as an object `{ name: 'Ed25519' }` would cause key operations to be delegated to the underlying runtime instead of the polyfill

--- a/packages/webcrypto-ed25519-polyfill/src/install.ts
+++ b/packages/webcrypto-ed25519-polyfill/src/install.ts
@@ -9,6 +9,12 @@ import {
     verifyPolyfill,
 } from './secrets';
 
+function isAlgorithmEd25519(putativeEd25519Algorithm: AlgorithmIdentifier): boolean {
+    const name =
+        typeof putativeEd25519Algorithm === 'string' ? putativeEd25519Algorithm : putativeEd25519Algorithm.name;
+    return name.localeCompare('ed25519', 'en-US', { sensitivity: 'base' }) === 0;
+}
+
 export function install() {
     if (__NODEJS__) {
         /**
@@ -48,7 +54,7 @@ export function install() {
         let originalGenerateKeySupportsEd25519: Promise<boolean> | boolean | undefined;
         originalSubtleCrypto.generateKey = (async (...args: Parameters<SubtleCrypto['generateKey']>) => {
             const [algorithm] = args;
-            if (algorithm !== 'Ed25519') {
+            if (!isAlgorithmEd25519(algorithm)) {
                 if (originalGenerateKey) {
                     return await originalGenerateKey.apply(originalSubtleCrypto, args);
                 } else {
@@ -142,7 +148,7 @@ export function install() {
         let originalImportKeySupportsEd25519: Promise<boolean> | boolean | undefined;
         originalSubtleCrypto.importKey = (async (...args: Parameters<SubtleCrypto['importKey']>) => {
             const [format, keyData, algorithm] = args;
-            if (algorithm !== 'Ed25519') {
+            if (!isAlgorithmEd25519(algorithm)) {
                 if (originalImportKey) {
                     return await originalImportKey.apply(originalSubtleCrypto, args);
                 } else {


### PR DESCRIPTION
#### Problem

The string `Ed25519` is not the only valid algorithm identifier for the Edwards curve. We need to support all of the other forms it could take.

#### Summary of Changes

Support both the string and the object form of the Ed25519 algorithm identifier, case insensitive.
