### PR TITLE
Fix for key operations in Firefox

### DIFF
--- a/.changeset/four-parents-retire.md
+++ b/.changeset/four-parents-retire.md
@@ -1,0 +1,5 @@
+---
+'@solana/keys': patch
+---
+
+Key operations now work in versions of Firefox that support `Ed25519` natively

--- a/examples/deserialize-transaction/src/example.ts
+++ b/examples/deserialize-transaction/src/example.ts
@@ -218,7 +218,9 @@ const signedBySignature = decodedTransaction.signatures[signedByAddress]!;
 const sourceAddressBytes = getAddressEncoder().encode(signedByAddress);
 // Then we create a public Ed25519 key with those bytes
 // This is a SubtleCrypto CryptoKey object that we create with role `verify`
-const signedByPublicKey = await crypto.subtle.importKey('raw', sourceAddressBytes, 'Ed25519', true, ['verify']);
+const signedByPublicKey = await crypto.subtle.importKey('raw', sourceAddressBytes, { name: 'Ed25519' }, true, [
+    'verify',
+]);
 // Now we can verify the signature using that key
 const verifiedSignature = await verifySignature(signedByPublicKey, signedBySignature, decodedTransaction.messageBytes);
 log.info(

--- a/packages/keys/src/algorithm.ts
+++ b/packages/keys/src/algorithm.ts
@@ -1,0 +1,4 @@
+export const ED25519_ALGORITHM_IDENTIFIER =
+    // Resist the temptation to convert this to a simple string; As of version 133.0.3, Firefox
+    // requires the object form of `AlgorithmIdentifier` and will throw a `DOMException` otherwise.
+    Object.freeze({ name: 'Ed25519' });

--- a/packages/keys/src/private-key.ts
+++ b/packages/keys/src/private-key.ts
@@ -1,6 +1,8 @@
 import { ReadonlyUint8Array } from '@solana/codecs-core';
 import { SOLANA_ERROR__KEYS__INVALID_PRIVATE_KEY_BYTE_LENGTH, SolanaError } from '@solana/errors';
 
+import { ED25519_ALGORITHM_IDENTIFIER } from './algorithm';
+
 function addPkcs8Header(bytes: ReadonlyUint8Array): ReadonlyUint8Array {
     // prettier-ignore
     return new Uint8Array([
@@ -46,5 +48,11 @@ export async function createPrivateKeyFromBytes(bytes: ReadonlyUint8Array, extra
         });
     }
     const privateKeyBytesPkcs8 = addPkcs8Header(bytes);
-    return await crypto.subtle.importKey('pkcs8', privateKeyBytesPkcs8, 'Ed25519', extractable ?? false, ['sign']);
+    return await crypto.subtle.importKey(
+        'pkcs8',
+        privateKeyBytesPkcs8,
+        ED25519_ALGORITHM_IDENTIFIER,
+        extractable ?? false,
+        ['sign'],
+    );
 }

--- a/packages/keys/src/signatures.ts
+++ b/packages/keys/src/signatures.ts
@@ -7,6 +7,8 @@ import {
     SolanaError,
 } from '@solana/errors';
 
+import { ED25519_ALGORITHM_IDENTIFIER } from './algorithm';
+
 export type Signature = string & { readonly __brand: unique symbol };
 export type SignatureBytes = Uint8Array & { readonly __brand: unique symbol };
 
@@ -58,7 +60,7 @@ export function isSignature(putativeSignature: string): putativeSignature is Sig
 
 export async function signBytes(key: CryptoKey, data: ReadonlyUint8Array): Promise<SignatureBytes> {
     assertSigningCapabilityIsAvailable();
-    const signedData = await crypto.subtle.sign('Ed25519', key, data);
+    const signedData = await crypto.subtle.sign(ED25519_ALGORITHM_IDENTIFIER, key, data);
     return new Uint8Array(signedData) as SignatureBytes;
 }
 
@@ -73,5 +75,5 @@ export async function verifySignature(
     data: ReadonlyUint8Array,
 ): Promise<boolean> {
     assertVerificationCapabilityIsAvailable();
-    return await crypto.subtle.verify('Ed25519', key, signature, data);
+    return await crypto.subtle.verify(ED25519_ALGORITHM_IDENTIFIER, key, signature, data);
 }

--- a/packages/webcrypto-ed25519-polyfill/src/install.ts
+++ b/packages/webcrypto-ed25519-polyfill/src/install.ts
@@ -12,7 +12,7 @@ import {
 function isAlgorithmEd25519(putativeEd25519Algorithm: AlgorithmIdentifier): boolean {
     const name =
         typeof putativeEd25519Algorithm === 'string' ? putativeEd25519Algorithm : putativeEd25519Algorithm.name;
-    return name.localeCompare('ed25519', 'en-US', { sensitivity: 'base' }) === 0;
+    return name.localeCompare('Ed25519', 'en-US', { sensitivity: 'base' }) === 0;
 }
 
 export function install() {


### PR DESCRIPTION
#### Problem

As of version 133.0.3 Firefox will throw a `DOMException` on this native code:

```ts
const kp = await crypto.subtle.generateKey("Ed25519", true, ["sign", "verify"]);
const b = await crypto.subtle.exportKey("raw", kp.publicKey);
const pub = await crypto.subtle.importKey(
  "raw",
  b,
  "Ed25519",
  /* extractable */ true,
  ["verify"]
); // Uncaught (in promise) DOMException: An invalid or illegal string was specified
```

#### Summary of Changes

Call the key operation functions with the object form of the `AlgorithmIdentifier` which Firefox appears to accept.
