### PR TITLE
fix: address issue in readme on keys example.

### DIFF
--- a/packages/signers/README.md
+++ b/packages/signers/README.md
@@ -326,7 +326,7 @@ const keypairFile = fs.readFileSync('~/.config/solana/id.json');
 const keypairBytes = new Uint8Array(JSON.parse(keypairFile.toString()));
 
 // Create a KeyPairSigner from the bytes.
-const { privateKey, publicKey } = await createKeyPairSignerFromBytes(keypairBytes);
+const { privateKey, publicKey } = await createKeyPairFromBytes(keypairBytes);
 ```
 
 #### `createKeyPairSignerFromPrivateKeyBytes()`


### PR DESCRIPTION
#### Problem

There is a typo in the example code given within the signers package.

#### Summary of Changes
Simply fixes the example code by using the correct function.