### PR TITLE
Document `@solana/assertions` with TypeDoc

### DIFF
--- a/packages/assertions/src/crypto.ts
+++ b/packages/assertions/src/crypto.ts
@@ -1,5 +1,9 @@
 import { SOLANA_ERROR__CRYPTO__RANDOM_VALUES_FUNCTION_UNIMPLEMENTED, SolanaError } from '@solana/errors';
 
+/**
+ * Throws an exception unless {@link Crypto#getRandomValues | `crypto.getRandomValues()`} is
+ * available in the current JavaScript environment.
+ */
 export function assertPRNGIsAvailable() {
     if (typeof globalThis.crypto === 'undefined' || typeof globalThis.crypto.getRandomValues !== 'function') {
         throw new SolanaError(SOLANA_ERROR__CRYPTO__RANDOM_VALUES_FUNCTION_UNIMPLEMENTED);

--- a/packages/assertions/src/index.ts
+++ b/packages/assertions/src/index.ts
@@ -1,3 +1,8 @@
-export * from './subtle-crypto';
-
+/**
+ * This package contains utilities for asserting that a JavaScript environment supports certain
+ * features necessary for the operation of the Solana JavaScript SDK.
+ *
+ * @packageDocumentation
+ */
 export * from './crypto';
+export * from './subtle-crypto';

--- a/packages/assertions/src/subtle-crypto.ts
+++ b/packages/assertions/src/subtle-crypto.ts
@@ -36,6 +36,10 @@ async function isEd25519CurveSupported(subtle: SubtleCrypto): Promise<boolean> {
     }
 }
 
+/**
+ * Throws an exception unless {@link SubtleCrypto#digest | `crypto.subtle.digest()`} is available in
+ * the current JavaScript environment.
+ */
 export function assertDigestCapabilityIsAvailable() {
     assertIsSecureContext();
     if (typeof globalThis.crypto === 'undefined' || typeof globalThis.crypto.subtle?.digest !== 'function') {
@@ -43,6 +47,10 @@ export function assertDigestCapabilityIsAvailable() {
     }
 }
 
+/**
+ * Throws an exception unless {@link SubtleCrypto#generateKey | `crypto.subtle.generateKey()`} is
+ * available in the current JavaScript environment and has support for the Ed25519 curve.
+ */
 export async function assertKeyGenerationIsAvailable() {
     assertIsSecureContext();
     if (typeof globalThis.crypto === 'undefined' || typeof globalThis.crypto.subtle?.generateKey !== 'function') {
@@ -53,6 +61,10 @@ export async function assertKeyGenerationIsAvailable() {
     }
 }
 
+/**
+ * Throws an exception unless {@link SubtleCrypto#exportKey | `crypto.subtle.exportKey()`} is
+ * available in the current JavaScript environment.
+ */
 export function assertKeyExporterIsAvailable() {
     assertIsSecureContext();
     if (typeof globalThis.crypto === 'undefined' || typeof globalThis.crypto.subtle?.exportKey !== 'function') {
@@ -60,13 +72,20 @@ export function assertKeyExporterIsAvailable() {
     }
 }
 
+/**
+ * Throws an exception unless {@link SubtleCrypto#sign | `crypto.subtle.sign()`} is available in the
+ * current JavaScript environment.
+ */
 export function assertSigningCapabilityIsAvailable() {
     assertIsSecureContext();
     if (typeof globalThis.crypto === 'undefined' || typeof globalThis.crypto.subtle?.sign !== 'function') {
         throw new SolanaError(SOLANA_ERROR__SUBTLE_CRYPTO__SIGN_FUNCTION_UNIMPLEMENTED);
     }
 }
-
+/**
+ * Throws an exception unless {@link SubtleCrypto#verify | `crypto.subtle.verify()`} is available in
+ * the current JavaScript environment.
+ */
 export function assertVerificationCapabilityIsAvailable() {
     assertIsSecureContext();
     if (typeof globalThis.crypto === 'undefined' || typeof globalThis.crypto.subtle?.verify !== 'function') {

--- a/packages/assertions/typedoc.json
+++ b/packages/assertions/typedoc.json
@@ -1,5 +1,6 @@
 {
     "$schema": "https://typedoc.org/schema.json",
     "extends": ["../typedoc.base.json"],
-    "entryPoints": ["src/index.ts"]
+    "entryPoints": ["src/index.ts"],
+    "readme": "none"
 }


### PR DESCRIPTION
This PR moves content from the README into the code.

Addresses #50

# Test Plan

```shell
cd packages/assertions
pnpm typedoc --watch \
  --plugin typedoc-plugin-missing-exports \
  --plugin typedoc-plugin-mdn-links
python3 -m http.server -d docs
```

Preview here: https://roaring-sable-5db1cc.netlify.app/
