### PR TITLE
Enable eslint rule, include AbortSignal types and disable some errors

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -11,7 +11,7 @@ export default [
             '@typescript-eslint/no-unsafe-assignment': 'off',
             '@typescript-eslint/no-unsafe-call': 'off',
             '@typescript-eslint/no-unsafe-enum-comparison': 'off',
-            '@typescript-eslint/no-unsafe-member-access': 'off',
+            '@typescript-eslint/no-unsafe-member-access': 'error',
             '@typescript-eslint/no-unsafe-return': 'off',
             '@typescript-eslint/only-throw-error': 'off',
             '@typescript-eslint/prefer-promise-reject-errors': 'error',

--- a/packages/library/src/__tests__/send-transaction-internal-test.ts
+++ b/packages/library/src/__tests__/send-transaction-internal-test.ts
@@ -156,6 +156,7 @@ describe('sendAndConfirmTransaction', () => {
             rpc,
             transaction: MOCK_TRANSACTION,
         }).catch(() => {});
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
         expect(createPendingRequest.mock.lastCall![1]).not.toHaveProperty('preflightCommitment');
     });
     it('returns the signature of the transaction', async () => {
@@ -311,6 +312,7 @@ describe('sendAndConfirmDurableNonceTransaction', () => {
             rpc,
             transaction: MOCK_DURABLE_NONCE_TRANSACTION,
         }).catch(() => {});
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
         expect(createPendingRequest.mock.lastCall![1]).not.toHaveProperty('preflightCommitment');
     });
     it('returns the signature of the transaction', async () => {

--- a/packages/rpc-graphql/src/loaders/account.ts
+++ b/packages/rpc-graphql/src/loaders/account.ts
@@ -50,13 +50,17 @@ export function sliceData(
             return codec.decode(codec.encode(data).slice(trueOffset, trueOffset + length));
         };
 
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
         if (Array.isArray(account.data)) {
+            // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
             const [data, encoding] = account.data;
             return {
                 ...account,
                 data: [slicedData(data, encoding), encoding],
             };
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
         } else if (typeof account.data === 'string') {
+            // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
             const data = account.data;
             return {
                 ...account,

--- a/packages/rpc-graphql/src/loaders/coalescer.ts
+++ b/packages/rpc-graphql/src/loaders/coalescer.ts
@@ -40,6 +40,7 @@ const hashOmit = <TArgs extends object>(args: TArgs, omit: (keyof TArgs)[]) => {
     const argsObj: any = {};
     for (const [key, value] of Object.entries(args)) {
         if (!omit.includes(key as keyof TArgs)) {
+            // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
             argsObj[key] = value;
         }
     }

--- a/packages/rpc-graphql/src/resolvers/transaction.ts
+++ b/packages/rpc-graphql/src/resolvers/transaction.ts
@@ -32,6 +32,7 @@ export function mapJsonParsedInstructions(instructions: readonly any[]): Instruc
     return instructions.map(instruction => {
         if ('parsed' in instruction) {
             // `jsonParsed`
+            // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
             if (typeof instruction.parsed === 'string' && instruction.program === 'spl-memo') {
                 const { parsed: memo, program: programName, programId } = instruction;
                 const instructionType = 'memo';

--- a/packages/rpc-subscriptions/src/__tests__/rpc-subscriptions-coalescer-test.ts
+++ b/packages/rpc-subscriptions/src/__tests__/rpc-subscriptions-coalescer-test.ts
@@ -130,6 +130,7 @@ describe('getRpcSubscriptionsTransportWithSubscriptionCoalescing', () => {
         coalescedTransport({ ...config, signal: abortControllerB.signal }).catch(() => {});
         abortControllerB.abort();
         jest.runAllTicks();
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
         expect(mockInnerTransport.mock.lastCall?.[0].signal).toHaveProperty('aborted', false);
     });
     it('fires the inner abort signal if all subscribers abort, in the same runloop', () => {
@@ -145,6 +146,7 @@ describe('getRpcSubscriptionsTransportWithSubscriptionCoalescing', () => {
         abortControllerA.abort();
         abortControllerB.abort();
         jest.runAllTicks();
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
         expect(mockInnerTransport.mock.lastCall?.[0].signal).toHaveProperty('aborted', true);
     });
     it('fires the inner abort signal if all subscribers abort, in different runloops', async () => {
@@ -162,6 +164,7 @@ describe('getRpcSubscriptionsTransportWithSubscriptionCoalescing', () => {
         abortControllerA.abort();
         abortControllerB.abort();
         jest.runAllTicks();
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
         expect(mockInnerTransport.mock.lastCall?.[0].signal).toHaveProperty('aborted', true);
     });
     it('does not fire the inner abort signal if the subscriber count is non zero at the end of the runloop, despite having aborted all in the middle of it', () => {
@@ -174,6 +177,7 @@ describe('getRpcSubscriptionsTransportWithSubscriptionCoalescing', () => {
         abortControllerA.abort();
         coalescedTransport({ ...config, signal: new AbortController().signal }).catch(() => {});
         jest.runAllTicks();
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
         expect(mockInnerTransport.mock.lastCall?.[0].signal).toHaveProperty('aborted', false);
     });
     it('does not re-coalesce new requests behind an errored transport', async () => {

--- a/packages/transaction-confirmation/src/__tests__/waiters-test.ts
+++ b/packages/transaction-confirmation/src/__tests__/waiters-test.ts
@@ -65,7 +65,7 @@ describe('waitForDurableNonceTransactionConfirmation', () => {
     });
     it('calls the abort signal passed to `getBlockHeightExceededPromise` when aborted', () => {
         const handleAbortOnBlockHeightExceedencePromise = jest.fn();
-        getNonceInvalidationPromise.mockImplementation(async ({ abortSignal }) => {
+        getNonceInvalidationPromise.mockImplementation(async ({ abortSignal }: { abortSignal: AbortSignal }) => {
             abortSignal.addEventListener('abort', handleAbortOnBlockHeightExceedencePromise);
             await FOREVER_PROMISE;
         });
@@ -82,7 +82,7 @@ describe('waitForDurableNonceTransactionConfirmation', () => {
     });
     it('calls the abort signal passed to `getRecentSignatureConfirmationPromise` when aborted', () => {
         const handleAbortOnSignatureConfirmationPromise = jest.fn();
-        getRecentSignatureConfirmationPromise.mockImplementation(async ({ abortSignal }) => {
+        getRecentSignatureConfirmationPromise.mockImplementation(async ({ abortSignal }: { abortSignal: AbortSignal }) => {
             abortSignal.addEventListener('abort', handleAbortOnSignatureConfirmationPromise);
             await FOREVER_PROMISE;
         });
@@ -284,7 +284,7 @@ describe('waitForRecentTransactionConfirmation', () => {
     });
     it('calls the abort signal passed to `getBlockHeightExceededPromise` when aborted', () => {
         const handleAbortOnBlockHeightExceedencePromise = jest.fn();
-        getBlockHeightExceedencePromise.mockImplementation(async ({ abortSignal }) => {
+        getBlockHeightExceedencePromise.mockImplementation(async ({ abortSignal }: { abortSignal: AbortSignal }) => {
             abortSignal.addEventListener('abort', handleAbortOnBlockHeightExceedencePromise);
             await FOREVER_PROMISE;
         });
@@ -301,7 +301,7 @@ describe('waitForRecentTransactionConfirmation', () => {
     });
     it('calls the abort signal passed to `getRecentSignatureConfirmationPromise` when aborted', () => {
         const handleAbortOnSignatureConfirmationPromise = jest.fn();
-        getRecentSignatureConfirmationPromise.mockImplementation(async ({ abortSignal }) => {
+        getRecentSignatureConfirmationPromise.mockImplementation(async ({ abortSignal }: { abortSignal: AbortSignal }) => {
             abortSignal.addEventListener('abort', handleAbortOnSignatureConfirmationPromise);
             await FOREVER_PROMISE;
         });
@@ -405,7 +405,7 @@ describe('waitForRecentTransactionConfirmationUntilTimeout', () => {
     });
     it('calls the abort signal passed to `getTimeoutPromise` when aborted', () => {
         const handleAbortOnTimeoutPromise = jest.fn();
-        getTimeoutPromise.mockImplementation(async ({ abortSignal }) => {
+        getTimeoutPromise.mockImplementation(async ({ abortSignal }: { abortSignal: AbortSignal }) => {
             abortSignal.addEventListener('abort', handleAbortOnTimeoutPromise);
             await FOREVER_PROMISE;
         });
@@ -422,7 +422,7 @@ describe('waitForRecentTransactionConfirmationUntilTimeout', () => {
     });
     it('calls the abort signal passed to `getRecentSignatureConfirmationPromise` when aborted', () => {
         const handleAbortOnSignatureConfirmationPromise = jest.fn();
-        getRecentSignatureConfirmationPromise.mockImplementation(async ({ abortSignal }) => {
+        getRecentSignatureConfirmationPromise.mockImplementation(async ({ abortSignal }: { abortSignal: AbortSignal }) => {
             abortSignal.addEventListener('abort', handleAbortOnSignatureConfirmationPromise);
             await FOREVER_PROMISE;
         });


### PR DESCRIPTION
#### Problem

Following https://github.com/anza-xyz/solana-web3.js/issues/13 , this PR intends to enable the eslint rule: no-unsafe-members

#### Summary of Changes

For most of the lint errors, they have been disabled for data flexibility. Only when the type was a bit more clear, it has been included
