### PR TITLE
Remove RpcApiMethods from README docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -397,8 +397,6 @@ This means the library can support future additions to the official [Solana JSON
 Here’s an example of how a developer at might build a custom RPC type-spec for an RPC provider's implementation of the Metaplex Digital Asset Standard's `getAsset` method:
 
 ```ts
-import { RpcApiMethods } from '@solana/web3.js';
-
 // Define the method's response payload.
 type GetAssetApiResponse = Readonly<{
     interface: DasApiAssetInterface;

--- a/packages/rpc-spec/README.md
+++ b/packages/rpc-spec/README.md
@@ -42,10 +42,6 @@ An object that exposes all of the functions described by `TRpcMethods`, and fulf
 
 For each of `TRpcMethods` this object exposes a method with the same name that maps between its input arguments and a `RpcPlan<TResponse>` that describes how to prepare a JSON RPC request to fetch `TResponse`.
 
-### `RpcApiMethods`
-
-This is a marker interface that all RPC method definitions must extend to be accepted for use with the `RpcApi` creator.
-
 ### `RpcPlan`
 
 This type allows an `RpcApi` to describe how a particular request should be issued to the JSON RPC server. Given a function that was called on a `Rpc`, this object returns an `execute` function that dictates which request will be sent, how the underlying transport will be used and how the responses will be transformed.


### PR DESCRIPTION
#### Problem

We don't export `RpcApiMethods` any more (see  https://github.com/solana-labs/solana-web3.js/pull/3213), but still have it referenced in the README. Using this snippet as-is will give a Typescript error

#### Summary of Changes

- Remove import from code example (it's not actually used in the code example)
- Remove outdated documentation of `RpcApiMethods` type, which is no longer exported