### PR TITLE
Fix accountKeys type in getTransaction JSON parsed

### DIFF
--- a/.changeset/red-melons-deny.md
+++ b/.changeset/red-melons-deny.md
@@ -1,0 +1,5 @@
+---
+'@solana/rpc-api': patch
+---
+
+Fix accountKeys type in getTransaction JSON parsed

--- a/packages/rpc-api/src/getTransaction.ts
+++ b/packages/rpc-api/src/getTransaction.ts
@@ -104,16 +104,16 @@ type ParsedTransactionInstruction = Readonly<{
     stackHeight?: number;
 }>;
 
+type ParsedAccount = Readonly<{
+    pubkey: Address;
+    signer: boolean;
+    source: 'lookupTable' | 'transaction';
+    writable: boolean;
+}>;
+
 type TransactionJsonParsed = Readonly<{
     message: {
-        accountKeys: [
-            {
-                pubkey: Address;
-                signer: boolean;
-                source: string;
-                writable: boolean;
-            },
-        ];
+        accountKeys: readonly ParsedAccount[];
         instructions: readonly (ParsedTransactionInstruction | PartiallyDecodedTransactionInstruction)[];
     };
 }> &


### PR DESCRIPTION
#### Problem

`accountKeys` was incorrectly typed as a list containing one account key, instead of a list of arbitrary length of account keys

#### Summary of Changes

- Fix the type
- Change the type of `source` to the enum it comes from (https://github.com/anza-xyz/agave/blob/8889b4ac1ea39121dffcbc95421dbffae737c1fe/transaction-status-client-types/src/lib.rs#L134-L148)

Fixes #80 