### PR TITLE
Fix docs description for `getInflationRate` and `getInflationReward` methods

### DIFF
--- a/packages/rpc-api/src/getInflationRate.ts
+++ b/packages/rpc-api/src/getInflationRate.ts
@@ -13,7 +13,7 @@ type GetInflationRateApiResponse = Readonly<{
 
 export type GetInflationRateApi = {
     /**
-     * Returns the current block height of the node
+     * Returns the specific inflation values for the current epoch
      */
     getInflationRate(
         // FIXME: https://github.com/solana-labs/solana-web3.js/issues/1389

--- a/packages/rpc-api/src/getInflationReward.ts
+++ b/packages/rpc-api/src/getInflationReward.ts
@@ -28,7 +28,7 @@ type GetInflationRewardApiResponse = readonly (InflationReward | null)[];
 
 export type GetInflationRewardApi = {
     /**
-     * Returns the current block height of the node
+     * Returns the inflation / staking reward for a list of addresses for an epoch
      */
     getInflationReward(addresses: Address[], config?: GetInflationRewardApiConfig): GetInflationRewardApiResponse;
 };


### PR DESCRIPTION
#### Problem
`getInflationRate` and `getInflationReward` methods have the description of `getBlockHeight`

#### Summary of Changes
Fix documentation description for `getInflationRate` and `getInflationReward` methods per their descriptions [here](https://solana.com/docs/rpc/http)
No code impacts/testing required.