### PR TITLE
Teach Mergify to use the Merge Queue

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -15,20 +15,12 @@ pull_request_rules:
   - name: Automatic merge (squash) on CI success
     conditions:
       - and:
-          - or:
-              - and:
-                  - base=maintenance/v1.x
-                  - and:
-                      - status-success~=^Lint, Build, and Test
-                      - status-success="Validate commit message"
-              - and:
-                  - base!=maintenance/v1.x
-                  - status-success=all-web3-checks
+          - status-success=all-web3-checks
           - label=automerge
           - label!=no-automerge
     actions:
-      merge:
-        method: squash
+      queue:
+        name: default
   - name: Remove automerge label on CI failure
     conditions:
       - label=automerge


### PR DESCRIPTION
I've heard this is the antidote to this error:

```
The pull request could not be merged
This could be related to an activated branch protection or ruleset rule that prevents us from merging. (detail: Repository rule violations found

Changes must be made through the merge queue
```

…is to enable this.

Also removed the references to the `maintenance/*` branches which have been left behind in `solana-labs`