### PR TITLE
Export `fetchLookupTables` from `library` and add tests

### DIFF
--- a/.changeset/tricky-beds-work.md
+++ b/.changeset/tricky-beds-work.md
@@ -1,0 +1,5 @@
+---
+'@solana/web3.js': patch
+---
+
+Add a new function `fetchAddressesForLookupTables` to fetch the addresses contained in a list of lookup tables'

--- a/packages/library/src/__tests__/fetch-lookup-tables-test.ts
+++ b/packages/library/src/__tests__/fetch-lookup-tables-test.ts
@@ -1,0 +1,137 @@
+import { Address } from '@solana/addresses';
+import {
+    SOLANA_ERROR__ACCOUNTS__EXPECTED_ALL_ACCOUNTS_TO_BE_DECODED,
+    SOLANA_ERROR__ACCOUNTS__ONE_OR_MORE_ACCOUNTS_NOT_FOUND,
+    SolanaError,
+} from '@solana/errors';
+import { GetMultipleAccountsApi, Rpc } from '@solana/rpc';
+
+import { fetchAddressesForLookupTables } from '../fetch-lookup-tables';
+
+describe('fetchAddressesForLookupTables', () => {
+    describe('when no lookup table addresses are provided', () => {
+        it('returns an empty object', async () => {
+            expect.assertions(1);
+            const rpc = {
+                getMultipleAccounts: jest.fn(),
+            };
+
+            const lookupTableAddresses: Address[] = [];
+            const lookupTables = await fetchAddressesForLookupTables(lookupTableAddresses, rpc);
+            expect(lookupTables).toEqual({});
+        });
+
+        it('does not call the RPC', async () => {
+            expect.assertions(1);
+            const rpc = {
+                getMultipleAccounts: jest.fn(),
+            };
+
+            const lookupTableAddresses: Address[] = [];
+            await fetchAddressesForLookupTables(lookupTableAddresses, rpc);
+            expect(rpc.getMultipleAccounts).not.toHaveBeenCalled();
+        });
+    });
+
+    describe('when lookup table addresses are provided', () => {
+        it('returns an object with the lookup table addresses as keys and the addresses as values', async () => {
+            expect.assertions(1);
+
+            const rpc: Rpc<GetMultipleAccountsApi> = {
+                getMultipleAccounts: jest.fn().mockReturnValue({
+                    send: jest.fn().mockResolvedValue({
+                        value: [
+                            {
+                                data: {
+                                    parsed: {
+                                        info: {
+                                            addresses: ['1111', '2222'],
+                                        },
+                                    },
+                                },
+                            },
+                            {
+                                data: {
+                                    parsed: {
+                                        info: {
+                                            addresses: ['3333'],
+                                        },
+                                    },
+                                },
+                            },
+                        ],
+                    }),
+                }),
+            };
+
+            const lookupTableAddresses: Address[] = ['abc' as Address, 'def' as Address];
+            const lookupTables = await fetchAddressesForLookupTables(lookupTableAddresses, rpc);
+
+            expect(lookupTables).toEqual({
+                abc: ['1111', '2222'],
+                def: ['3333'],
+            });
+        });
+
+        it('throws when the RPC returns invalid data', async () => {
+            expect.assertions(1);
+
+            const rpc: Rpc<GetMultipleAccountsApi> = {
+                getMultipleAccounts: jest.fn().mockReturnValue({
+                    send: jest.fn().mockResolvedValue({
+                        value: [
+                            {
+                                data: {
+                                    parsed: {
+                                        info: {
+                                            addresses: ['1111', '2222'],
+                                        },
+                                    },
+                                },
+                            },
+                            {
+                                data: ['', 'base64'],
+                            },
+                        ],
+                    }),
+                }),
+            };
+
+            const lookupTableAddresses: Address[] = ['abc' as Address, 'def' as Address];
+            await expect(fetchAddressesForLookupTables(lookupTableAddresses, rpc)).rejects.toThrow(
+                new SolanaError(SOLANA_ERROR__ACCOUNTS__EXPECTED_ALL_ACCOUNTS_TO_BE_DECODED, {
+                    addresses: ['def'],
+                }),
+            );
+        });
+
+        it('throws when the RPC returns missing data', async () => {
+            expect.assertions(1);
+
+            const rpc: Rpc<GetMultipleAccountsApi> = {
+                getMultipleAccounts: jest.fn().mockReturnValue({
+                    send: jest.fn().mockResolvedValue({
+                        value: [
+                            // returns abc, not def
+                            {
+                                data: {
+                                    parsed: {
+                                        info: {
+                                            addresses: ['1111', '2222'],
+                                        },
+                                    },
+                                },
+                            },
+                            null,
+                        ],
+                    }),
+                }),
+            };
+
+            const lookupTableAddresses: Address[] = ['abc' as Address, 'def' as Address];
+            await expect(fetchAddressesForLookupTables(lookupTableAddresses, rpc)).rejects.toThrow(
+                new SolanaError(SOLANA_ERROR__ACCOUNTS__ONE_OR_MORE_ACCOUNTS_NOT_FOUND, { addresses: ['def'] }),
+            );
+        });
+    });
+});

--- a/packages/library/src/fetch-lookup-tables.ts
+++ b/packages/library/src/fetch-lookup-tables.ts
@@ -1,0 +1,39 @@
+import {
+    assertAccountsDecoded,
+    assertAccountsExist,
+    type FetchAccountsConfig,
+    fetchJsonParsedAccounts,
+} from '@solana/accounts';
+import type { Address } from '@solana/addresses';
+import type { GetMultipleAccountsApi, Rpc } from '@solana/rpc';
+import { type AddressesByLookupTableAddress } from '@solana/transaction-messages';
+
+type FetchedAddressLookup = {
+    addresses: Address[];
+};
+
+export async function fetchAddressesForLookupTables(
+    lookupTableAddresses: Address[],
+    rpc: Rpc<GetMultipleAccountsApi>,
+    config?: FetchAccountsConfig,
+): Promise<AddressesByLookupTableAddress> {
+    if (lookupTableAddresses.length === 0) {
+        return {};
+    }
+
+    const fetchedLookupTables = await fetchJsonParsedAccounts<FetchedAddressLookup[]>(
+        rpc,
+        lookupTableAddresses,
+        config,
+    );
+
+    assertAccountsDecoded(fetchedLookupTables);
+    assertAccountsExist(fetchedLookupTables);
+
+    return fetchedLookupTables.reduce<AddressesByLookupTableAddress>((acc, lookup) => {
+        return {
+            ...acc,
+            [lookup.address]: lookup.data.addresses,
+        };
+    }, {});
+}

--- a/packages/library/src/index.ts
+++ b/packages/library/src/index.ts
@@ -16,6 +16,7 @@ export * from '@solana/transactions';
 export * from './airdrop';
 export * from './compute-limit';
 export * from './decompile-transaction-message-fetching-lookup-tables';
+export * from './fetch-lookup-tables';
 export * from './send-and-confirm-durable-nonce-transaction';
 export * from './send-and-confirm-transaction';
 export * from './send-transaction-without-confirming';


### PR DESCRIPTION
#### Problem

`fetchLookupTables` is a useful function that was used as part of decoding transaction messages, but not separately exported. It returns `AddressesByLookupTableAddress` which maps the input lookup tables to their list of addresses. This is useful outside of the context of decoding transaction messages, for example it's used as the input to `compressTransactionMessageUsingAddressLookupTables`.

#### Summary of Changes

- Extract `fetchLookupTables` into its own file
- Export it from `library`
- Add unit tests 

Fixes #93 