### PR TITLE
Document `@solana/codecs-numbers` with TypeDoc

### DIFF
--- a/packages/codecs-numbers/src/assertions.ts
+++ b/packages/codecs-numbers/src/assertions.ts
@@ -1,7 +1,29 @@
 import { SOLANA_ERROR__CODECS__NUMBER_OUT_OF_RANGE, SolanaError } from '@solana/errors';
 
 /**
- * Asserts that a given number is between a given range.
+ * Ensures that a given number falls within a specified range.
+ *
+ * If the number is outside the allowed range, an error is thrown.
+ * This function is primarily used to validate values before encoding them in a codec.
+ *
+ * @param codecDescription - A string describing the codec that is performing the validation.
+ * @param min - The minimum allowed value (inclusive).
+ * @param max - The maximum allowed value (inclusive).
+ * @param value - The number to validate.
+ *
+ * @throws {@link SolanaError} if the value is out of range.
+ *
+ * @example
+ * Validating a number within range.
+ * ```ts
+ * assertNumberIsBetweenForCodec('u8', 0, 255, 42); // Passes
+ * ```
+ *
+ * @example
+ * Throwing an error for an out-of-range value.
+ * ```ts
+ * assertNumberIsBetweenForCodec('u8', 0, 255, 300); // Throws
+ * ```
  */
 export function assertNumberIsBetweenForCodec(
     codecDescription: string,

--- a/packages/codecs-numbers/src/common.ts
+++ b/packages/codecs-numbers/src/common.ts
@@ -1,37 +1,93 @@
 import { Codec, Decoder, Encoder, FixedSizeCodec, FixedSizeDecoder, FixedSizeEncoder } from '@solana/codecs-core';
-
-/** Defines a encoder for numbers and bigints. */
+/**
+ * Represents an encoder for numbers and bigints.
+ *
+ * This type allows encoding values that are either `number` or `bigint`.
+ * Depending on the specific implementation, the encoded output may have a fixed or variable size.
+ *
+ * @see {@link FixedSizeNumberEncoder}
+ */
 export type NumberEncoder = Encoder<bigint | number>;
 
-/** Defines a fixed-size encoder for numbers and bigints. */
+/**
+ * Represents a fixed-size encoder for numbers and bigints.
+ *
+ * This encoder serializes values using an exact number of bytes, defined by `TSize`.
+ *
+ * @typeParam TSize - The number of bytes used for encoding.
+ *
+ * @see {@link NumberEncoder}
+ */
 export type FixedSizeNumberEncoder<TSize extends number = number> = FixedSizeEncoder<bigint | number, TSize>;
 
-/** Defines a decoder for numbers and bigints. */
+/**
+ * Represents a decoder for numbers and bigints.
+ *
+ * This type supports decoding values as either `number` or `bigint`, depending on the implementation.
+ *
+ * @see {@link FixedSizeNumberDecoder}
+ */
 export type NumberDecoder = Decoder<bigint> | Decoder<number>;
 
-/** Defines a fixed-size decoder for numbers and bigints. */
+/**
+ * Represents a fixed-size decoder for numbers and bigints.
+ *
+ * This decoder reads a fixed number of bytes (`TSize`) and converts them into a `number` or `bigint`.
+ *
+ * @typeParam TSize - The number of bytes expected for decoding.
+ *
+ * @see {@link NumberDecoder}
+ */
 export type FixedSizeNumberDecoder<TSize extends number = number> =
     | FixedSizeDecoder<bigint, TSize>
     | FixedSizeDecoder<number, TSize>;
 
-/** Defines a codec for numbers and bigints. */
+/**
+ * Represents a codec for encoding and decoding numbers and bigints.
+ *
+ * - The encoded value can be either a `number` or a `bigint`.
+ * - The decoded value will always be either a `number` or `bigint`, depending on the implementation.
+ *
+ * @see {@link FixedSizeNumberCodec}
+ */
 export type NumberCodec = Codec<bigint | number, bigint> | Codec<bigint | number, number>;
 
-/** Defines a fixed-size codec for numbers and bigints. */
+/**
+ * Represents a fixed-size codec for encoding and decoding numbers and bigints.
+ *
+ * This codec uses a specific number of bytes (`TSize`) for serialization.
+ * The encoded value can be either a `number` or `bigint`, but the decoded value will always be a `number` or `bigint`,
+ * depending on the implementation.
+ *
+ * @typeParam TSize - The number of bytes used for encoding and decoding.
+ *
+ * @see {@link NumberCodec}
+ */
 export type FixedSizeNumberCodec<TSize extends number = number> =
     | FixedSizeCodec<bigint | number, bigint, TSize>
     | FixedSizeCodec<bigint | number, number, TSize>;
 
-/** Defines the config for number codecs that use more than one byte. */
+/**
+ * Configuration options for number codecs that use more than one byte.
+ *
+ * This configuration applies to all number codecs except `u8` and `i8`,
+ * allowing the user to specify the endianness of serialization.
+ */
 export type NumberCodecConfig = {
     /**
-     * Whether the serializer should use little-endian or big-endian encoding.
+     * Specifies whether numbers should be encoded in little-endian or big-endian format.
+     *
      * @defaultValue `Endian.Little`
      */
     endian?: Endian;
 };
 
-/** Defines the endianness of a number serializer. */
+/**
+ * Defines the byte order used for number serialization.
+ *
+ * - `Little`: The least significant byte is stored first.
+ * - `Big`: The most significant byte is stored first.
+ */
 export enum Endian {
     Little,
     Big,

--- a/packages/codecs-numbers/src/f32.ts
+++ b/packages/codecs-numbers/src/f32.ts
@@ -3,6 +3,26 @@ import { combineCodec, FixedSizeCodec, FixedSizeDecoder, FixedSizeEncoder } from
 import { NumberCodecConfig } from './common';
 import { numberDecoderFactory, numberEncoderFactory } from './utils';
 
+/**
+ * Returns an encoder for 32-bit floating-point numbers (`f32`).
+ *
+ * This encoder serializes `f32` values using 4 bytes.
+ * Floating-point values may lose precision when encoded.
+ *
+ * For more details, see {@link getF32Codec}.
+ *
+ * @param config - Optional configuration to specify endianness (little by default).
+ * @returns A `FixedSizeEncoder<number, 4>` for encoding `f32` values.
+ *
+ * @example
+ * Encoding an `f32` value.
+ * ```ts
+ * const encoder = getF32Encoder();
+ * const bytes = encoder.encode(-1.5); // 0x0000c0bf
+ * ```
+ *
+ * @see {@link getF32Codec}
+ */
 export const getF32Encoder = (config: NumberCodecConfig = {}): FixedSizeEncoder<bigint | number, 4> =>
     numberEncoderFactory({
         config,
@@ -11,6 +31,26 @@ export const getF32Encoder = (config: NumberCodecConfig = {}): FixedSizeEncoder<
         size: 4,
     });
 
+/**
+ * Returns a decoder for 32-bit floating-point numbers (`f32`).
+ *
+ * This decoder deserializes `f32` values from 4 bytes.
+ * Some precision may be lost during decoding due to floating-point representation.
+ *
+ * For more details, see {@link getF32Codec}.
+ *
+ * @param config - Optional configuration to specify endianness (little by default).
+ * @returns A `FixedSizeDecoder<number, 4>` for decoding `f32` values.
+ *
+ * @example
+ * Decoding an `f32` value.
+ * ```ts
+ * const decoder = getF32Decoder();
+ * const value = decoder.decode(new Uint8Array([0x00, 0x00, 0xc0, 0xbf])); // -1.5
+ * ```
+ *
+ * @see {@link getF32Codec}
+ */
 export const getF32Decoder = (config: NumberCodecConfig = {}): FixedSizeDecoder<number, 4> =>
     numberDecoderFactory({
         config,
@@ -19,5 +59,46 @@ export const getF32Decoder = (config: NumberCodecConfig = {}): FixedSizeDecoder<
         size: 4,
     });
 
+/**
+ * Returns a codec for encoding and decoding 32-bit floating-point numbers (`f32`).
+ *
+ * This codec serializes `f32` values using 4 bytes.
+ * Due to the IEEE 754 floating-point representation, some precision loss may occur.
+ *
+ * @param config - Optional configuration to specify endianness (little by default).
+ * @returns A `FixedSizeCodec<number, number, 4>` for encoding and decoding `f32` values.
+ *
+ * @example
+ * Encoding and decoding an `f32` value.
+ * ```ts
+ * const codec = getF32Codec();
+ * const bytes = codec.encode(-1.5); // 0x0000c0bf
+ * const value = codec.decode(bytes); // -1.5
+ * ```
+ *
+ * @example
+ * Using big-endian encoding.
+ * ```ts
+ * const codec = getF32Codec({ endian: Endian.Big });
+ * const bytes = codec.encode(-1.5); // 0xbfc00000
+ * ```
+ *
+ * @remarks
+ * `f32` values follow the IEEE 754 single-precision floating-point standard.
+ * Precision loss may occur for certain values.
+ *
+ * - If you need higher precision, consider using {@link getF64Codec}.
+ * - If you need integer values, consider using {@link getI32Codec} or {@link getU32Codec}.
+ *
+ * Separate {@link getF32Encoder} and {@link getF32Decoder} functions are available.
+ *
+ * ```ts
+ * const bytes = getF32Encoder().encode(-1.5);
+ * const value = getF32Decoder().decode(bytes);
+ * ```
+ *
+ * @see {@link getF32Encoder}
+ * @see {@link getF32Decoder}
+ */
 export const getF32Codec = (config: NumberCodecConfig = {}): FixedSizeCodec<bigint | number, number, 4> =>
     combineCodec(getF32Encoder(config), getF32Decoder(config));

--- a/packages/codecs-numbers/src/f64.ts
+++ b/packages/codecs-numbers/src/f64.ts
@@ -3,6 +3,26 @@ import { combineCodec, FixedSizeCodec, FixedSizeDecoder, FixedSizeEncoder } from
 import { NumberCodecConfig } from './common';
 import { numberDecoderFactory, numberEncoderFactory } from './utils';
 
+/**
+ * Returns an encoder for 64-bit floating-point numbers (`f64`).
+ *
+ * This encoder serializes `f64` values using 8 bytes.
+ * Floating-point values may lose precision when encoded.
+ *
+ * For more details, see {@link getF64Codec}.
+ *
+ * @param config - Optional configuration to specify endianness (little by default).
+ * @returns A `FixedSizeEncoder<number, 8>` for encoding `f64` values.
+ *
+ * @example
+ * Encoding an `f64` value.
+ * ```ts
+ * const encoder = getF64Encoder();
+ * const bytes = encoder.encode(-1.5); // 0x000000000000f8bf
+ * ```
+ *
+ * @see {@link getF64Codec}
+ */
 export const getF64Encoder = (config: NumberCodecConfig = {}): FixedSizeEncoder<bigint | number, 8> =>
     numberEncoderFactory({
         config,
@@ -11,6 +31,26 @@ export const getF64Encoder = (config: NumberCodecConfig = {}): FixedSizeEncoder<
         size: 8,
     });
 
+/**
+ * Returns a decoder for 64-bit floating-point numbers (`f64`).
+ *
+ * This decoder deserializes `f64` values from 8 bytes.
+ * Some precision may be lost during decoding due to floating-point representation.
+ *
+ * For more details, see {@link getF64Codec}.
+ *
+ * @param config - Optional configuration to specify endianness (little by default).
+ * @returns A `FixedSizeDecoder<number, 8>` for decoding `f64` values.
+ *
+ * @example
+ * Decoding an `f64` value.
+ * ```ts
+ * const decoder = getF64Decoder();
+ * const value = decoder.decode(new Uint8Array([0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0xf8, 0xbf])); // -1.5
+ * ```
+ *
+ * @see {@link getF64Codec}
+ */
 export const getF64Decoder = (config: NumberCodecConfig = {}): FixedSizeDecoder<number, 8> =>
     numberDecoderFactory({
         config,
@@ -19,5 +59,46 @@ export const getF64Decoder = (config: NumberCodecConfig = {}): FixedSizeDecoder<
         size: 8,
     });
 
+/**
+ * Returns a codec for encoding and decoding 64-bit floating-point numbers (`f64`).
+ *
+ * This codec serializes `f64` values using 8 bytes.
+ * Due to the IEEE 754 floating-point representation, some precision loss may occur.
+ *
+ * @param config - Optional configuration to specify endianness (little by default).
+ * @returns A `FixedSizeCodec<number, number, 8>` for encoding and decoding `f64` values.
+ *
+ * @example
+ * Encoding and decoding an `f64` value.
+ * ```ts
+ * const codec = getF64Codec();
+ * const bytes = codec.encode(-1.5); // 0x000000000000f8bf
+ * const value = codec.decode(bytes); // -1.5
+ * ```
+ *
+ * @example
+ * Using big-endian encoding.
+ * ```ts
+ * const codec = getF64Codec({ endian: Endian.Big });
+ * const bytes = codec.encode(-1.5); // 0xbff8000000000000
+ * ```
+ *
+ * @remarks
+ * `f64` values follow the IEEE 754 double-precision floating-point standard.
+ * Precision loss may still occur but is significantly lower than `f32`.
+ *
+ * - If you need smaller floating-point values, consider using {@link getF32Codec}.
+ * - If you need integer values, consider using {@link getI64Codec} or {@link getU64Codec}.
+ *
+ * Separate {@link getF64Encoder} and {@link getF64Decoder} functions are available.
+ *
+ * ```ts
+ * const bytes = getF64Encoder().encode(-1.5);
+ * const value = getF64Decoder().decode(bytes);
+ * ```
+ *
+ * @see {@link getF64Encoder}
+ * @see {@link getF64Decoder}
+ */
 export const getF64Codec = (config: NumberCodecConfig = {}): FixedSizeCodec<bigint | number, number, 8> =>
     combineCodec(getF64Encoder(config), getF64Decoder(config));

--- a/packages/codecs-numbers/src/i128.ts
+++ b/packages/codecs-numbers/src/i128.ts
@@ -3,6 +3,26 @@ import { combineCodec, FixedSizeCodec, FixedSizeDecoder, FixedSizeEncoder } from
 import { NumberCodecConfig } from './common';
 import { numberDecoderFactory, numberEncoderFactory } from './utils';
 
+/**
+ * Returns an encoder for 128-bit signed integers (`i128`).
+ *
+ * This encoder serializes `i128` values using 16 bytes.
+ * Values can be provided as either `number` or `bigint`.
+ *
+ * For more details, see {@link getI128Codec}.
+ *
+ * @param config - Optional configuration to specify endianness (little by default).
+ * @returns A `FixedSizeEncoder<number | bigint, 16>` for encoding `i128` values.
+ *
+ * @example
+ * Encoding an `i128` value.
+ * ```ts
+ * const encoder = getI128Encoder();
+ * const bytes = encoder.encode(-42n); // 0xd6ffffffffffffffffffffffffffffff
+ * ```
+ *
+ * @see {@link getI128Codec}
+ */
 export const getI128Encoder = (config: NumberCodecConfig = {}): FixedSizeEncoder<bigint | number, 16> =>
     numberEncoderFactory({
         config,
@@ -18,6 +38,29 @@ export const getI128Encoder = (config: NumberCodecConfig = {}): FixedSizeEncoder
         size: 16,
     });
 
+/**
+ * Returns a decoder for 128-bit signed integers (`i128`).
+ *
+ * This decoder deserializes `i128` values from 16 bytes.
+ * The decoded value is always a `bigint`.
+ *
+ * For more details, see {@link getI128Codec}.
+ *
+ * @param config - Optional configuration to specify endianness (little by default).
+ * @returns A `FixedSizeDecoder<bigint, 16>` for decoding `i128` values.
+ *
+ * @example
+ * Decoding an `i128` value.
+ * ```ts
+ * const decoder = getI128Decoder();
+ * const value = decoder.decode(new Uint8Array([
+ *   0xd6, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff,
+ *   0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff
+ * ])); // -42n
+ * ```
+ *
+ * @see {@link getI128Codec}
+ */
 export const getI128Decoder = (config: NumberCodecConfig = {}): FixedSizeDecoder<bigint, 16> =>
     numberDecoderFactory({
         config,
@@ -32,5 +75,47 @@ export const getI128Decoder = (config: NumberCodecConfig = {}): FixedSizeDecoder
         size: 16,
     });
 
+/**
+ * Returns a codec for encoding and decoding 128-bit signed integers (`i128`).
+ *
+ * This codec serializes `i128` values using 16 bytes.
+ * Values can be provided as either `number` or `bigint`, but the decoded value is always a `bigint`.
+ *
+ * @param config - Optional configuration to specify endianness (little by default).
+ * @returns A `FixedSizeCodec<number | bigint, bigint, 16>` for encoding and decoding `i128` values.
+ *
+ * @example
+ * Encoding and decoding an `i128` value.
+ * ```ts
+ * const codec = getI128Codec();
+ * const bytes = codec.encode(-42n); // 0xd6ffffffffffffffffffffffffffffff
+ * const value = codec.decode(bytes); // -42n
+ * ```
+ *
+ * @example
+ * Using big-endian encoding.
+ * ```ts
+ * const codec = getI128Codec({ endian: Endian.Big });
+ * const bytes = codec.encode(-42n); // 0xffffffffffffffffffffffffffffd6
+ * ```
+ *
+ * @remarks
+ * This codec supports values between `-2^127` and `2^127 - 1`.
+ * Since JavaScript `number` cannot safely represent values beyond `2^53 - 1`, the decoded value is always a `bigint`.
+ *
+ * - If you need a smaller signed integer, consider using {@link getI64Codec} or {@link getI32Codec}.
+ * - If you need a larger signed integer, consider using a custom codec.
+ * - If you need unsigned integers, consider using {@link getU128Codec}.
+ *
+ * Separate {@link getI128Encoder} and {@link getI128Decoder} functions are available.
+ *
+ * ```ts
+ * const bytes = getI128Encoder().encode(-42);
+ * const value = getI128Decoder().decode(bytes);
+ * ```
+ *
+ * @see {@link getI128Encoder}
+ * @see {@link getI128Decoder}
+ */
 export const getI128Codec = (config: NumberCodecConfig = {}): FixedSizeCodec<bigint | number, bigint, 16> =>
     combineCodec(getI128Encoder(config), getI128Decoder(config));

--- a/packages/codecs-numbers/src/i16.ts
+++ b/packages/codecs-numbers/src/i16.ts
@@ -3,6 +3,26 @@ import { combineCodec, FixedSizeCodec, FixedSizeDecoder, FixedSizeEncoder } from
 import { NumberCodecConfig } from './common';
 import { numberDecoderFactory, numberEncoderFactory } from './utils';
 
+/**
+ * Returns an encoder for 16-bit signed integers (`i16`).
+ *
+ * This encoder serializes `i16` values using 2 bytes.
+ * Values can be provided as either `number` or `bigint`.
+ *
+ * For more details, see {@link getI16Codec}.
+ *
+ * @param config - Optional configuration to specify endianness (little by default).
+ * @returns A `FixedSizeEncoder<number | bigint, 2>` for encoding `i16` values.
+ *
+ * @example
+ * Encoding an `i16` value.
+ * ```ts
+ * const encoder = getI16Encoder();
+ * const bytes = encoder.encode(-42); // 0xd6ff
+ * ```
+ *
+ * @see {@link getI16Codec}
+ */
 export const getI16Encoder = (config: NumberCodecConfig = {}): FixedSizeEncoder<bigint | number, 2> =>
     numberEncoderFactory({
         config,
@@ -12,6 +32,26 @@ export const getI16Encoder = (config: NumberCodecConfig = {}): FixedSizeEncoder<
         size: 2,
     });
 
+/**
+ * Returns a decoder for 16-bit signed integers (`i16`).
+ *
+ * This decoder deserializes `i16` values from 2 bytes.
+ * The decoded value is always a `number`.
+ *
+ * For more details, see {@link getI16Codec}.
+ *
+ * @param config - Optional configuration to specify endianness (little by default).
+ * @returns A `FixedSizeDecoder<number, 2>` for decoding `i16` values.
+ *
+ * @example
+ * Decoding an `i16` value.
+ * ```ts
+ * const decoder = getI16Decoder();
+ * const value = decoder.decode(new Uint8Array([0xd6, 0xff])); // -42
+ * ```
+ *
+ * @see {@link getI16Codec}
+ */
 export const getI16Decoder = (config: NumberCodecConfig = {}): FixedSizeDecoder<number, 2> =>
     numberDecoderFactory({
         config,
@@ -20,5 +60,46 @@ export const getI16Decoder = (config: NumberCodecConfig = {}): FixedSizeDecoder<
         size: 2,
     });
 
+/**
+ * Returns a codec for encoding and decoding 16-bit signed integers (`i16`).
+ *
+ * This codec serializes `i16` values using 2 bytes.
+ * Values can be provided as either `number` or `bigint`, but the decoded value is always a `number`.
+ *
+ * @param config - Optional configuration to specify endianness (little by default).
+ * @returns A `FixedSizeCodec<number | bigint, number, 2>` for encoding and decoding `i16` values.
+ *
+ * @example
+ * Encoding and decoding an `i16` value.
+ * ```ts
+ * const codec = getI16Codec();
+ * const bytes = codec.encode(-42); // 0xd6ff
+ * const value = codec.decode(bytes); // -42
+ * ```
+ *
+ * @example
+ * Using big-endian encoding.
+ * ```ts
+ * const codec = getI16Codec({ endian: Endian.Big });
+ * const bytes = codec.encode(-42); // 0xffd6
+ * ```
+ *
+ * @remarks
+ * This codec supports values between `-2^15` (`-32,768`) and `2^15 - 1` (`32,767`).
+ *
+ * - If you need a smaller signed integer, consider using {@link getI8Codec}.
+ * - If you need a larger signed integer, consider using {@link getI32Codec}.
+ * - If you need unsigned integers, consider using {@link getU16Codec}.
+ *
+ * Separate {@link getI16Encoder} and {@link getI16Decoder} functions are available.
+ *
+ * ```ts
+ * const bytes = getI16Encoder().encode(-42);
+ * const value = getI16Decoder().decode(bytes);
+ * ```
+ *
+ * @see {@link getI16Encoder}
+ * @see {@link getI16Decoder}
+ */
 export const getI16Codec = (config: NumberCodecConfig = {}): FixedSizeCodec<bigint | number, number, 2> =>
     combineCodec(getI16Encoder(config), getI16Decoder(config));

--- a/packages/codecs-numbers/src/i32.ts
+++ b/packages/codecs-numbers/src/i32.ts
@@ -3,6 +3,26 @@ import { combineCodec, FixedSizeCodec, FixedSizeDecoder, FixedSizeEncoder } from
 import { NumberCodecConfig } from './common';
 import { numberDecoderFactory, numberEncoderFactory } from './utils';
 
+/**
+ * Returns an encoder for 32-bit signed integers (`i32`).
+ *
+ * This encoder serializes `i32` values using 4 bytes.
+ * Values can be provided as either `number` or `bigint`.
+ *
+ * For more details, see {@link getI32Codec}.
+ *
+ * @param config - Optional configuration to specify endianness (little by default).
+ * @returns A `FixedSizeEncoder<number | bigint, 4>` for encoding `i32` values.
+ *
+ * @example
+ * Encoding an `i32` value.
+ * ```ts
+ * const encoder = getI32Encoder();
+ * const bytes = encoder.encode(-42); // 0xd6ffffff
+ * ```
+ *
+ * @see {@link getI32Codec}
+ */
 export const getI32Encoder = (config: NumberCodecConfig = {}): FixedSizeEncoder<bigint | number, 4> =>
     numberEncoderFactory({
         config,
@@ -12,6 +32,26 @@ export const getI32Encoder = (config: NumberCodecConfig = {}): FixedSizeEncoder<
         size: 4,
     });
 
+/**
+ * Returns a decoder for 32-bit signed integers (`i32`).
+ *
+ * This decoder deserializes `i32` values from 4 bytes.
+ * The decoded value is always a `number`.
+ *
+ * For more details, see {@link getI32Codec}.
+ *
+ * @param config - Optional configuration to specify endianness (little by default).
+ * @returns A `FixedSizeDecoder<number, 4>` for decoding `i32` values.
+ *
+ * @example
+ * Decoding an `i32` value.
+ * ```ts
+ * const decoder = getI32Decoder();
+ * const value = decoder.decode(new Uint8Array([0xd6, 0xff, 0xff, 0xff])); // -42
+ * ```
+ *
+ * @see {@link getI32Codec}
+ */
 export const getI32Decoder = (config: NumberCodecConfig = {}): FixedSizeDecoder<number, 4> =>
     numberDecoderFactory({
         config,
@@ -20,5 +60,46 @@ export const getI32Decoder = (config: NumberCodecConfig = {}): FixedSizeDecoder<
         size: 4,
     });
 
+/**
+ * Returns a codec for encoding and decoding 32-bit signed integers (`i32`).
+ *
+ * This codec serializes `i32` values using 4 bytes.
+ * Values can be provided as either `number` or `bigint`, but the decoded value is always a `number`.
+ *
+ * @param config - Optional configuration to specify endianness (little by default).
+ * @returns A `FixedSizeCodec<number | bigint, number, 4>` for encoding and decoding `i32` values.
+ *
+ * @example
+ * Encoding and decoding an `i32` value.
+ * ```ts
+ * const codec = getI32Codec();
+ * const bytes = codec.encode(-42); // 0xd6ffffff
+ * const value = codec.decode(bytes); // -42
+ * ```
+ *
+ * @example
+ * Using big-endian encoding.
+ * ```ts
+ * const codec = getI32Codec({ endian: Endian.Big });
+ * const bytes = codec.encode(-42); // 0xffffffd6
+ * ```
+ *
+ * @remarks
+ * This codec supports values between `-2^31` (`-2,147,483,648`) and `2^31 - 1` (`2,147,483,647`).
+ *
+ * - If you need a smaller signed integer, consider using {@link getI16Codec} or {@link getI8Codec}.
+ * - If you need a larger signed integer, consider using {@link getI64Codec}.
+ * - If you need unsigned integers, consider using {@link getU32Codec}.
+ *
+ * Separate {@link getI32Encoder} and {@link getI32Decoder} functions are available.
+ *
+ * ```ts
+ * const bytes = getI32Encoder().encode(-42);
+ * const value = getI32Decoder().decode(bytes);
+ * ```
+ *
+ * @see {@link getI32Encoder}
+ * @see {@link getI32Decoder}
+ */
 export const getI32Codec = (config: NumberCodecConfig = {}): FixedSizeCodec<bigint | number, number, 4> =>
     combineCodec(getI32Encoder(config), getI32Decoder(config));

--- a/packages/codecs-numbers/src/i64.ts
+++ b/packages/codecs-numbers/src/i64.ts
@@ -3,6 +3,26 @@ import { combineCodec, FixedSizeCodec, FixedSizeDecoder, FixedSizeEncoder } from
 import { NumberCodecConfig } from './common';
 import { numberDecoderFactory, numberEncoderFactory } from './utils';
 
+/**
+ * Returns an encoder for 64-bit signed integers (`i64`).
+ *
+ * This encoder serializes `i64` values using 8 bytes.
+ * Values can be provided as either `number` or `bigint`.
+ *
+ * For more details, see {@link getI64Codec}.
+ *
+ * @param config - Optional configuration to specify endianness (little by default).
+ * @returns A `FixedSizeEncoder<number | bigint, 8>` for encoding `i64` values.
+ *
+ * @example
+ * Encoding an `i64` value.
+ * ```ts
+ * const encoder = getI64Encoder();
+ * const bytes = encoder.encode(-42n); // 0xd6ffffffffffffff
+ * ```
+ *
+ * @see {@link getI64Codec}
+ */
 export const getI64Encoder = (config: NumberCodecConfig = {}): FixedSizeEncoder<bigint | number, 8> =>
     numberEncoderFactory({
         config,
@@ -12,6 +32,28 @@ export const getI64Encoder = (config: NumberCodecConfig = {}): FixedSizeEncoder<
         size: 8,
     });
 
+/**
+ * Returns a decoder for 64-bit signed integers (`i64`).
+ *
+ * This decoder deserializes `i64` values from 8 bytes.
+ * The decoded value is always a `bigint`.
+ *
+ * For more details, see {@link getI64Codec}.
+ *
+ * @param config - Optional configuration to specify endianness (little by default).
+ * @returns A `FixedSizeDecoder<bigint, 8>` for decoding `i64` values.
+ *
+ * @example
+ * Decoding an `i64` value.
+ * ```ts
+ * const decoder = getI64Decoder();
+ * const value = decoder.decode(new Uint8Array([
+ *   0xd6, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff
+ * ])); // -42n
+ * ```
+ *
+ * @see {@link getI64Codec}
+ */
 export const getI64Decoder = (config: NumberCodecConfig = {}): FixedSizeDecoder<bigint, 8> =>
     numberDecoderFactory({
         config,
@@ -20,5 +62,47 @@ export const getI64Decoder = (config: NumberCodecConfig = {}): FixedSizeDecoder<
         size: 8,
     });
 
+/**
+ * Returns a codec for encoding and decoding 64-bit signed integers (`i64`).
+ *
+ * This codec serializes `i64` values using 8 bytes.
+ * Values can be provided as either `number` or `bigint`, but the decoded value is always a `bigint`.
+ *
+ * @param config - Optional configuration to specify endianness (little by default).
+ * @returns A `FixedSizeCodec<number | bigint, bigint, 8>` for encoding and decoding `i64` values.
+ *
+ * @example
+ * Encoding and decoding an `i64` value.
+ * ```ts
+ * const codec = getI64Codec();
+ * const bytes = codec.encode(-42n); // 0xd6ffffffffffffff
+ * const value = codec.decode(bytes); // -42n
+ * ```
+ *
+ * @example
+ * Using big-endian encoding.
+ * ```ts
+ * const codec = getI64Codec({ endian: Endian.Big });
+ * const bytes = codec.encode(-42n); // 0xffffffffffffffd6
+ * ```
+ *
+ * @remarks
+ * This codec supports values between `-2^63` and `2^63 - 1`.
+ * Since JavaScript `number` cannot safely represent values beyond `2^53 - 1`, the decoded value is always a `bigint`.
+ *
+ * - If you need a smaller signed integer, consider using {@link getI32Codec} or {@link getI16Codec}.
+ * - If you need a larger signed integer, consider using {@link getI128Codec}.
+ * - If you need unsigned integers, consider using {@link getU64Codec}.
+ *
+ * Separate {@link getI64Encoder} and {@link getI64Decoder} functions are available.
+ *
+ * ```ts
+ * const bytes = getI64Encoder().encode(-42);
+ * const value = getI64Decoder().decode(bytes);
+ * ```
+ *
+ * @see {@link getI64Encoder}
+ * @see {@link getI64Decoder}
+ */
 export const getI64Codec = (config: NumberCodecConfig = {}): FixedSizeCodec<bigint | number, bigint, 8> =>
     combineCodec(getI64Encoder(config), getI64Decoder(config));

--- a/packages/codecs-numbers/src/i8.ts
+++ b/packages/codecs-numbers/src/i8.ts
@@ -2,6 +2,25 @@ import { combineCodec, FixedSizeCodec, FixedSizeDecoder, FixedSizeEncoder } from
 
 import { numberDecoderFactory, numberEncoderFactory } from './utils';
 
+/**
+ * Returns an encoder for 8-bit signed integers (`i8`).
+ *
+ * This encoder serializes `i8` values using 1 byte.
+ * Values can be provided as either `number` or `bigint`.
+ *
+ * For more details, see {@link getI8Codec}.
+ *
+ * @returns A `FixedSizeEncoder<number | bigint, 1>` for encoding `i8` values.
+ *
+ * @example
+ * Encoding an `i8` value.
+ * ```ts
+ * const encoder = getI8Encoder();
+ * const bytes = encoder.encode(-42); // 0xd6
+ * ```
+ *
+ * @see {@link getI8Codec}
+ */
 export const getI8Encoder = (): FixedSizeEncoder<bigint | number, 1> =>
     numberEncoderFactory({
         name: 'i8',
@@ -10,6 +29,25 @@ export const getI8Encoder = (): FixedSizeEncoder<bigint | number, 1> =>
         size: 1,
     });
 
+/**
+ * Returns a decoder for 8-bit signed integers (`i8`).
+ *
+ * This decoder deserializes `i8` values from 1 byte.
+ * The decoded value is always a `number`.
+ *
+ * For more details, see {@link getI8Codec}.
+ *
+ * @returns A `FixedSizeDecoder<number, 1>` for decoding `i8` values.
+ *
+ * @example
+ * Decoding an `i8` value.
+ * ```ts
+ * const decoder = getI8Decoder();
+ * const value = decoder.decode(new Uint8Array([0xd6])); // -42
+ * ```
+ *
+ * @see {@link getI8Codec}
+ */
 export const getI8Decoder = (): FixedSizeDecoder<number, 1> =>
     numberDecoderFactory({
         get: view => view.getInt8(0),
@@ -17,5 +55,37 @@ export const getI8Decoder = (): FixedSizeDecoder<number, 1> =>
         size: 1,
     });
 
+/**
+ * Returns a codec for encoding and decoding 8-bit signed integers (`i8`).
+ *
+ * This codec serializes `i8` values using 1 byte.
+ * Values can be provided as either `number` or `bigint`, but the decoded value is always a `number`.
+ *
+ * @returns A `FixedSizeCodec<number | bigint, number, 1>` for encoding and decoding `i8` values.
+ *
+ * @example
+ * Encoding and decoding an `i8` value.
+ * ```ts
+ * const codec = getI8Codec();
+ * const bytes = codec.encode(-42); // 0xd6
+ * const value = codec.decode(bytes); // -42
+ * ```
+ *
+ * @remarks
+ * This codec supports values between `-2^7` (`-128`) and `2^7 - 1` (`127`).
+ *
+ * - If you need a larger signed integer, consider using {@link getI16Codec}.
+ * - If you need an unsigned integer, consider using {@link getU8Codec}.
+ *
+ * Separate {@link getI8Encoder} and {@link getI8Decoder} functions are available.
+ *
+ * ```ts
+ * const bytes = getI8Encoder().encode(-42);
+ * const value = getI8Decoder().decode(bytes);
+ * ```
+ *
+ * @see {@link getI8Encoder}
+ * @see {@link getI8Decoder}
+ */
 export const getI8Codec = (): FixedSizeCodec<bigint | number, number, 1> =>
     combineCodec(getI8Encoder(), getI8Decoder());

--- a/packages/codecs-numbers/src/index.ts
+++ b/packages/codecs-numbers/src/index.ts
@@ -1,3 +1,13 @@
+/**
+ * This package contains codecs for numbers of different sizes and endianness.
+ * It can be used standalone, but it is also exported as part of the Solana JavaScript SDK
+ * [`@solana/web3.js@next`](https://github.com/anza-xyz/solana-web3.js/tree/main/packages/library).
+ *
+ * This package is also part of the [`@solana/codecs` package](https://github.com/anza-xyz/solana-web3.js/tree/main/packages/codecs)
+ * which acts as an entry point for all codec packages as well as for their documentation.
+ *
+ * @packageDocumentation
+ */
 export * from './assertions';
 export * from './common';
 export * from './f32';

--- a/packages/codecs-numbers/src/short-u16.ts
+++ b/packages/codecs-numbers/src/short-u16.ts
@@ -12,8 +12,25 @@ import {
 import { assertNumberIsBetweenForCodec } from './assertions';
 
 /**
- * Encodes short u16 numbers.
- * @see {@link getShortU16Codec} for a more detailed description.
+ * Returns an encoder for `shortU16` values.
+ *
+ * This encoder serializes `shortU16` values using **1 to 3 bytes**.
+ * Smaller values use fewer bytes, while larger values take up more space.
+ *
+ * For more details, see {@link getShortU16Codec}.
+ *
+ * @returns A `VariableSizeEncoder<number | bigint>` for encoding `shortU16` values.
+ *
+ * @example
+ * Encoding a `shortU16` value.
+ * ```ts
+ * const encoder = getShortU16Encoder();
+ * encoder.encode(42);    // 0x2a
+ * encoder.encode(128);   // 0x8001
+ * encoder.encode(16384); // 0x808001
+ * ```
+ *
+ * @see {@link getShortU16Codec}
  */
 export const getShortU16Encoder = (): VariableSizeEncoder<bigint | number> =>
     createEncoder({
@@ -47,8 +64,25 @@ export const getShortU16Encoder = (): VariableSizeEncoder<bigint | number> =>
     });
 
 /**
- * Decodes short u16 numbers.
- * @see {@link getShortU16Codec} for a more detailed description.
+ * Returns a decoder for `shortU16` values.
+ *
+ * This decoder deserializes `shortU16` values from **1 to 3 bytes**.
+ * The number of bytes used depends on the encoded value.
+ *
+ * For more details, see {@link getShortU16Codec}.
+ *
+ * @returns A `VariableSizeDecoder<number>` for decoding `shortU16` values.
+ *
+ * @example
+ * Decoding a `shortU16` value.
+ * ```ts
+ * const decoder = getShortU16Decoder();
+ * decoder.decode(new Uint8Array([0x2a]));             // 42
+ * decoder.decode(new Uint8Array([0x80, 0x01]));       // 128
+ * decoder.decode(new Uint8Array([0x80, 0x80, 0x01])); // 16384
+ * ```
+ *
+ * @see {@link getShortU16Codec}
  */
 export const getShortU16Decoder = (): VariableSizeDecoder<number> =>
     createDecoder({
@@ -72,13 +106,53 @@ export const getShortU16Decoder = (): VariableSizeDecoder<number> =>
     });
 
 /**
- * Encodes and decodes short u16 numbers.
+ * Returns a codec for encoding and decoding `shortU16` values.
  *
- * Short u16 numbers are the same as u16, but serialized with 1 to 3 bytes.
- * If the value is above 0x7f, the top bit is set and the remaining
- * value is stored in the next bytes. Each byte follows the same
- * pattern until the 3rd byte. The 3rd byte, if needed, uses
- * all 8 bits to store the last byte of the original value.
+ * It serializes unsigned integers using **1 to 3 bytes** based on the encoded value.
+ * The larger the value, the more bytes it uses.
+ *
+ * - If the value is `<= 0x7f` (127), it is stored in a **single byte**
+ *   and the first bit is set to `0` to indicate the end of the value.
+ * - Otherwise, the first bit is set to `1` to indicate that the value continues in the next byte, which follows the same pattern.
+ * - This process repeats until the value is fully encoded in up to 3 bytes. The third and last byte, if needed, uses all 8 bits to store the remaining value.
+ *
+ * In other words, the encoding scheme follows this structure:
+ *
+ * ```txt
+ * 0XXXXXXX                   <- Values 0 to 127 (1 byte)
+ * 1XXXXXXX 0XXXXXXX          <- Values 128 to 16,383 (2 bytes)
+ * 1XXXXXXX 1XXXXXXX XXXXXXXX <- Values 16,384 to 4,194,303 (3 bytes)
+ * ```
+ *
+ * @returns A `VariableSizeCodec<number | bigint, number>` for encoding and decoding `shortU16` values.
+ *
+ * @example
+ * Encoding and decoding `shortU16` values.
+ * ```ts
+ * const codec = getShortU16Codec();
+ * const bytes1 = codec.encode(42);    // 0x2a
+ * const bytes2 = codec.encode(128);   // 0x8001
+ * const bytes3 = codec.encode(16384); // 0x808001
+ *
+ * codec.decode(bytes1); // 42
+ * codec.decode(bytes2); // 128
+ * codec.decode(bytes3); // 16384
+ * ```
+ *
+ * @remarks
+ * This codec efficiently stores small numbers, making it useful for transactions and compact representations.
+ *
+ * If you need a fixed-size `u16` codec, consider using {@link getU16Codec}.
+ *
+ * Separate {@link getShortU16Encoder} and {@link getShortU16Decoder} functions are available.
+ *
+ * ```ts
+ * const bytes = getShortU16Encoder().encode(42);
+ * const value = getShortU16Decoder().decode(bytes);
+ * ```
+ *
+ * @see {@link getShortU16Encoder}
+ * @see {@link getShortU16Decoder}
  */
 export const getShortU16Codec = (): VariableSizeCodec<bigint | number, number> =>
     combineCodec(getShortU16Encoder(), getShortU16Decoder());

--- a/packages/codecs-numbers/src/u128.ts
+++ b/packages/codecs-numbers/src/u128.ts
@@ -3,6 +3,26 @@ import { combineCodec, FixedSizeCodec, FixedSizeDecoder, FixedSizeEncoder } from
 import { NumberCodecConfig } from './common';
 import { numberDecoderFactory, numberEncoderFactory } from './utils';
 
+/**
+ * Returns an encoder for 128-bit unsigned integers (`u128`).
+ *
+ * This encoder serializes `u128` values using sixteen bytes in little-endian format by default.
+ * You may specify big-endian storage using the `endian` option.
+ *
+ * For more details, see {@link getU128Codec}.
+ *
+ * @param config - Optional settings for endianness.
+ * @returns A `FixedSizeEncoder<number | bigint, 16>` for encoding `u128` values.
+ *
+ * @example
+ * Encoding a `u128` value.
+ * ```ts
+ * const encoder = getU128Encoder();
+ * const bytes = encoder.encode(42n); // 0x2a000000000000000000000000000000
+ * ```
+ *
+ * @see {@link getU128Codec}
+ */
 export const getU128Encoder = (config: NumberCodecConfig = {}): FixedSizeEncoder<bigint | number, 16> =>
     numberEncoderFactory({
         config,
@@ -18,6 +38,26 @@ export const getU128Encoder = (config: NumberCodecConfig = {}): FixedSizeEncoder
         size: 16,
     });
 
+/**
+ * Returns a decoder for 128-bit unsigned integers (`u128`).
+ *
+ * This decoder deserializes `u128` values from sixteen bytes in little-endian format by default.
+ * You may specify big-endian storage using the `endian` option.
+ *
+ * For more details, see {@link getU128Codec}.
+ *
+ * @param config - Optional settings for endianness.
+ * @returns A `FixedSizeDecoder<bigint, 16>` for decoding `u128` values.
+ *
+ * @example
+ * Decoding a `u128` value.
+ * ```ts
+ * const decoder = getU128Decoder();
+ * const value = decoder.decode(new Uint8Array([0x2a, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00])); // 42n
+ * ```
+ *
+ * @see {@link getU128Codec}
+ */
 export const getU128Decoder = (config: NumberCodecConfig = {}): FixedSizeDecoder<bigint, 16> =>
     numberDecoderFactory({
         config,
@@ -32,5 +72,46 @@ export const getU128Decoder = (config: NumberCodecConfig = {}): FixedSizeDecoder
         size: 16,
     });
 
+/**
+ * Returns a codec for encoding and decoding 128-bit unsigned integers (`u128`).
+ *
+ * This codec serializes `u128` values using 16 bytes.
+ * Values can be provided as either `number` or `bigint`, but the decoded value is always a `bigint`.
+ *
+ * @param config - Optional configuration to specify endianness (little by default).
+ * @returns A `FixedSizeCodec<number | bigint, bigint, 16>` for encoding and decoding `u128` values.
+ *
+ * @example
+ * Encoding and decoding a `u128` value.
+ * ```ts
+ * const codec = getU128Codec();
+ * const bytes = codec.encode(42); // 0x2a000000000000000000000000000000
+ * const value = codec.decode(bytes); // 42n
+ * ```
+ *
+ * @example
+ * Using big-endian encoding.
+ * ```ts
+ * const codec = getU128Codec({ endian: Endian.Big });
+ * const bytes = codec.encode(42); // 0x0000000000000000000000000000002a
+ * ```
+ *
+ * @remarks
+ * This codec supports values between `0` and `2^128 - 1`.
+ * Since JavaScript `number` cannot safely represent values beyond `2^53 - 1`, the decoded value is always a `bigint`.
+ *
+ * - If you need a smaller unsigned integer, consider using {@link getU64Codec} or {@link getU32Codec}.
+ * - If you need signed integers, consider using {@link getI128Codec}.
+ *
+ * Separate {@link getU128Encoder} and {@link getU128Decoder} functions are available.
+ *
+ * ```ts
+ * const bytes = getU128Encoder().encode(42);
+ * const value = getU128Decoder().decode(bytes);
+ * ```
+ *
+ * @see {@link getU128Encoder}
+ * @see {@link getU128Decoder}
+ */
 export const getU128Codec = (config: NumberCodecConfig = {}): FixedSizeCodec<bigint | number, bigint, 16> =>
     combineCodec(getU128Encoder(config), getU128Decoder(config));

--- a/packages/codecs-numbers/src/u16.ts
+++ b/packages/codecs-numbers/src/u16.ts
@@ -3,6 +3,26 @@ import { combineCodec, FixedSizeCodec, FixedSizeDecoder, FixedSizeEncoder } from
 import { NumberCodecConfig } from './common';
 import { numberDecoderFactory, numberEncoderFactory } from './utils';
 
+/**
+ * Returns an encoder for 16-bit unsigned integers (`u16`).
+ *
+ * This encoder serializes `u16` values using two bytes in little-endian format by default.
+ * You may specify big-endian storage using the `endian` option.
+ *
+ * For more details, see {@link getU16Codec}.
+ *
+ * @param config - Optional settings for endianness.
+ * @returns A `FixedSizeEncoder<number | bigint, 2>` for encoding `u16` values.
+ *
+ * @example
+ * Encoding a `u16` value.
+ * ```ts
+ * const encoder = getU16Encoder();
+ * const bytes = encoder.encode(42); // 0x2a00
+ * ```
+ *
+ * @see {@link getU16Codec}
+ */
 export const getU16Encoder = (config: NumberCodecConfig = {}): FixedSizeEncoder<bigint | number, 2> =>
     numberEncoderFactory({
         config,
@@ -12,6 +32,26 @@ export const getU16Encoder = (config: NumberCodecConfig = {}): FixedSizeEncoder<
         size: 2,
     });
 
+/**
+ * Returns a decoder for 16-bit unsigned integers (`u16`).
+ *
+ * This decoder deserializes `u16` values from two bytes in little-endian format by default.
+ * You may specify big-endian storage using the `endian` option.
+ *
+ * For more details, see {@link getU16Codec}.
+ *
+ * @param config - Optional settings for endianness.
+ * @returns A `FixedSizeDecoder<number, 2>` for decoding `u16` values.
+ *
+ * @example
+ * Decoding a `u16` value.
+ * ```ts
+ * const decoder = getU16Decoder();
+ * const value = decoder.decode(new Uint8Array([0x2a, 0x00])); // 42
+ * ```
+ *
+ * @see {@link getU16Codec}
+ */
 export const getU16Decoder = (config: NumberCodecConfig = {}): FixedSizeDecoder<number, 2> =>
     numberDecoderFactory({
         config,
@@ -20,5 +60,44 @@ export const getU16Decoder = (config: NumberCodecConfig = {}): FixedSizeDecoder<
         size: 2,
     });
 
+/**
+ * Returns a codec for encoding and decoding 16-bit unsigned integers (`u16`).
+ *
+ * This codec serializes `u16` values using two bytes in little-endian format by default.
+ * You may specify big-endian storage using the `endian` option.
+ *
+ * @param config - Optional settings for endianness.
+ * @returns A `FixedSizeCodec<number | bigint, number, 2>` for encoding and decoding `u16` values.
+ *
+ * @example
+ * Encoding and decoding a `u16` value.
+ * ```ts
+ * const codec = getU16Codec();
+ * const bytes = codec.encode(42); // 0x2a00 (little-endian)
+ * const value = codec.decode(bytes); // 42
+ * ```
+ *
+ * @example
+ * Storing values in big-endian format.
+ * ```ts
+ * const codec = getU16Codec({ endian: Endian.Big });
+ * const bytes = codec.encode(42); // 0x002a
+ * ```
+ *
+ * @remarks
+ * This codec supports values between `0` and `2^16 - 1`.
+ * If you need a larger range, consider using {@link getU32Codec} or {@link getU64Codec}.
+ * For signed integers, use {@link getI16Codec}.
+ *
+ * Separate {@link getU16Encoder} and {@link getU16Decoder} functions are available.
+ *
+ * ```ts
+ * const bytes = getU16Encoder().encode(42);
+ * const value = getU16Decoder().decode(bytes);
+ * ```
+ *
+ * @see {@link getU16Encoder}
+ * @see {@link getU16Decoder}
+ */
 export const getU16Codec = (config: NumberCodecConfig = {}): FixedSizeCodec<bigint | number, number, 2> =>
     combineCodec(getU16Encoder(config), getU16Decoder(config));

--- a/packages/codecs-numbers/src/u32.ts
+++ b/packages/codecs-numbers/src/u32.ts
@@ -3,6 +3,26 @@ import { combineCodec, FixedSizeCodec, FixedSizeDecoder, FixedSizeEncoder } from
 import { NumberCodecConfig } from './common';
 import { numberDecoderFactory, numberEncoderFactory } from './utils';
 
+/**
+ * Returns an encoder for 32-bit unsigned integers (`u32`).
+ *
+ * This encoder serializes `u32` values using four bytes in little-endian format by default.
+ * You may specify big-endian storage using the `endian` option.
+ *
+ * For more details, see {@link getU32Codec}.
+ *
+ * @param config - Optional settings for endianness.
+ * @returns A `FixedSizeEncoder<bigint | number, 4>` for encoding `u32` values.
+ *
+ * @example
+ * Encoding a `u32` value.
+ * ```ts
+ * const encoder = getU32Encoder();
+ * const bytes = encoder.encode(42); // 0x2a000000
+ * ```
+ *
+ * @see {@link getU32Codec}
+ */
 export const getU32Encoder = (config: NumberCodecConfig = {}): FixedSizeEncoder<bigint | number, 4> =>
     numberEncoderFactory({
         config,
@@ -12,6 +32,26 @@ export const getU32Encoder = (config: NumberCodecConfig = {}): FixedSizeEncoder<
         size: 4,
     });
 
+/**
+ * Returns a decoder for 32-bit unsigned integers (`u32`).
+ *
+ * This decoder deserializes `u32` values from four bytes in little-endian format by default.
+ * You may specify big-endian storage using the `endian` option.
+ *
+ * For more details, see {@link getU32Codec}.
+ *
+ * @param config - Optional settings for endianness.
+ * @returns A `FixedSizeDecoder<number, 4>` for decoding `u32` values.
+ *
+ * @example
+ * Decoding a `u32` value.
+ * ```ts
+ * const decoder = getU32Decoder();
+ * const value = decoder.decode(new Uint8Array([0x2a, 0x00, 0x00, 0x00])); // 42
+ * ```
+ *
+ * @see {@link getU32Codec}
+ */
 export const getU32Decoder = (config: NumberCodecConfig = {}): FixedSizeDecoder<number, 4> =>
     numberDecoderFactory({
         config,
@@ -20,5 +60,44 @@ export const getU32Decoder = (config: NumberCodecConfig = {}): FixedSizeDecoder<
         size: 4,
     });
 
+/**
+ * Returns a codec for encoding and decoding 32-bit unsigned integers (`u32`).
+ *
+ * This codec serializes `u32` values using four bytes in little-endian format by default.
+ * You may specify big-endian storage using the `endian` option.
+ *
+ * @param config - Optional settings for endianness.
+ * @returns A `FixedSizeCodec<bigint | number, number, 4>` for encoding and decoding `u32` values.
+ *
+ * @example
+ * Encoding and decoding a `u32` value.
+ * ```ts
+ * const codec = getU32Codec();
+ * const bytes = codec.encode(42); // 0x2a000000 (little-endian)
+ * const value = codec.decode(bytes); // 42
+ * ```
+ *
+ * @example
+ * Storing values in big-endian format.
+ * ```ts
+ * const codec = getU32Codec({ endian: Endian.Big });
+ * const bytes = codec.encode(42); // 0x0000002a
+ * ```
+ *
+ * @remarks
+ * This codec only supports values between `0` and `2^32 - 1`.
+ * If you need a larger range, consider using {@link getU64Codec} or {@link getU128Codec}.
+ * For signed integers, use {@link getI32Codec}.
+ *
+ * Separate {@link getU32Encoder} and {@link getU32Decoder} functions are available.
+ *
+ * ```ts
+ * const bytes = getU32Encoder().encode(42);
+ * const value = getU32Decoder().decode(bytes);
+ * ```
+ *
+ * @see {@link getU32Encoder}
+ * @see {@link getU32Decoder}
+ */
 export const getU32Codec = (config: NumberCodecConfig = {}): FixedSizeCodec<bigint | number, number, 4> =>
     combineCodec(getU32Encoder(config), getU32Decoder(config));

--- a/packages/codecs-numbers/src/u64.ts
+++ b/packages/codecs-numbers/src/u64.ts
@@ -3,6 +3,26 @@ import { combineCodec, FixedSizeCodec, FixedSizeDecoder, FixedSizeEncoder } from
 import { NumberCodecConfig } from './common';
 import { numberDecoderFactory, numberEncoderFactory } from './utils';
 
+/**
+ * Returns an encoder for 64-bit unsigned integers (`u64`).
+ *
+ * This encoder serializes `u64` values using 8 bytes.
+ * Values can be provided as either `number` or `bigint`.
+ *
+ * For more details, see {@link getU64Codec}.
+ *
+ * @param config - Optional configuration to specify endianness (little by default).
+ * @returns A `FixedSizeEncoder<number | bigint, 8>` for encoding `u64` values.
+ *
+ * @example
+ * Encoding a `u64` value.
+ * ```ts
+ * const encoder = getU64Encoder();
+ * const bytes = encoder.encode(42); // 0x2a00000000000000
+ * ```
+ *
+ * @see {@link getU64Codec}
+ */
 export const getU64Encoder = (config: NumberCodecConfig = {}): FixedSizeEncoder<bigint | number, 8> =>
     numberEncoderFactory({
         config,
@@ -12,6 +32,26 @@ export const getU64Encoder = (config: NumberCodecConfig = {}): FixedSizeEncoder<
         size: 8,
     });
 
+/**
+ * Returns a decoder for 64-bit unsigned integers (`u64`).
+ *
+ * This decoder deserializes `u64` values from 8 bytes.
+ * The decoded value is always a `bigint`.
+ *
+ * For more details, see {@link getU64Codec}.
+ *
+ * @param config - Optional configuration to specify endianness (little by default).
+ * @returns A `FixedSizeDecoder<bigint, 8>` for decoding `u64` values.
+ *
+ * @example
+ * Decoding a `u64` value.
+ * ```ts
+ * const decoder = getU64Decoder();
+ * const value = decoder.decode(new Uint8Array([0x2a, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00])); // 42n
+ * ```
+ *
+ * @see {@link getU64Codec}
+ */
 export const getU64Decoder = (config: NumberCodecConfig = {}): FixedSizeDecoder<bigint, 8> =>
     numberDecoderFactory({
         config,
@@ -20,5 +60,47 @@ export const getU64Decoder = (config: NumberCodecConfig = {}): FixedSizeDecoder<
         size: 8,
     });
 
+/**
+ * Returns a codec for encoding and decoding 64-bit unsigned integers (`u64`).
+ *
+ * This codec serializes `u64` values using 8 bytes.
+ * Values can be provided as either `number` or `bigint`, but the decoded value is always a `bigint`.
+ *
+ * @param config - Optional configuration to specify endianness (little by default).
+ * @returns A `FixedSizeCodec<number | bigint, bigint, 8>` for encoding and decoding `u64` values.
+ *
+ * @example
+ * Encoding and decoding a `u64` value.
+ * ```ts
+ * const codec = getU64Codec();
+ * const bytes = codec.encode(42); // 0x2a00000000000000
+ * const value = codec.decode(bytes); // 42n
+ * ```
+ *
+ * @example
+ * Using big-endian encoding.
+ * ```ts
+ * const codec = getU64Codec({ endian: Endian.Big });
+ * const bytes = codec.encode(42); // 0x000000000000002a
+ * ```
+ *
+ * @remarks
+ * This codec supports values between `0` and `2^64 - 1`.
+ * Since JavaScript `number` cannot safely represent values beyond `2^53 - 1`, the decoded value is always a `bigint`.
+ *
+ * - If you need a smaller unsigned integer, consider using {@link getU32Codec} or {@link getU16Codec}.
+ * - If you need a larger unsigned integer, consider using {@link getU128Codec}.
+ * - If you need signed integers, consider using {@link getI64Codec}.
+ *
+ * Separate {@link getU64Encoder} and {@link getU64Decoder} functions are available.
+ *
+ * ```ts
+ * const bytes = getU64Encoder().encode(42);
+ * const value = getU64Decoder().decode(bytes);
+ * ```
+ *
+ * @see {@link getU64Encoder}
+ * @see {@link getU64Decoder}
+ */
 export const getU64Codec = (config: NumberCodecConfig = {}): FixedSizeCodec<bigint | number, bigint, 8> =>
     combineCodec(getU64Encoder(config), getU64Decoder(config));

--- a/packages/codecs-numbers/src/u8.ts
+++ b/packages/codecs-numbers/src/u8.ts
@@ -2,6 +2,24 @@ import { combineCodec, FixedSizeCodec, FixedSizeDecoder, FixedSizeEncoder } from
 
 import { numberDecoderFactory, numberEncoderFactory } from './utils';
 
+/**
+ * Returns an encoder for 8-bit unsigned integers (`u8`).
+ *
+ * This encoder serializes `u8` values using a single byte.
+ *
+ * For more details, see {@link getU8Codec}.
+ *
+ * @returns A `FixedSizeEncoder<number | bigint, 1>` for encoding `u8` values.
+ *
+ * @example
+ * Encoding a `u8` value.
+ * ```ts
+ * const encoder = getU8Encoder();
+ * const bytes = encoder.encode(42); // 0x2a
+ * ```
+ *
+ * @see {@link getU8Codec}
+ */
 export const getU8Encoder = (): FixedSizeEncoder<bigint | number, 1> =>
     numberEncoderFactory({
         name: 'u8',
@@ -10,6 +28,24 @@ export const getU8Encoder = (): FixedSizeEncoder<bigint | number, 1> =>
         size: 1,
     });
 
+/**
+ * Returns a decoder for 8-bit unsigned integers (`u8`).
+ *
+ * This decoder deserializes `u8` values from a single byte.
+ *
+ * For more details, see {@link getU8Codec}.
+ *
+ * @returns A `FixedSizeDecoder<number, 1>` for decoding `u8` values.
+ *
+ * @example
+ * Decoding a `u8` value.
+ * ```ts
+ * const decoder = getU8Decoder();
+ * const value = decoder.decode(new Uint8Array([0xff])); // 255
+ * ```
+ *
+ * @see {@link getU8Codec}
+ */
 export const getU8Decoder = (): FixedSizeDecoder<number, 1> =>
     numberDecoderFactory({
         get: view => view.getUint8(0),
@@ -17,5 +53,35 @@ export const getU8Decoder = (): FixedSizeDecoder<number, 1> =>
         size: 1,
     });
 
+/**
+ * Returns a codec for encoding and decoding 8-bit unsigned integers (`u8`).
+ *
+ * This codec serializes `u8` values using a single byte.
+ *
+ * @returns A `FixedSizeCodec<number | bigint, number, 1>` for encoding and decoding `u8` values.
+ *
+ * @example
+ * Encoding and decoding a `u8` value.
+ * ```ts
+ * const codec = getU8Codec();
+ * const bytes = codec.encode(255); // 0xff
+ * const value = codec.decode(bytes); // 255
+ * ```
+ *
+ * @remarks
+ * This codec supports values between `0` and `2^8 - 1` (0 to 255).
+ * If you need larger integers, consider using {@link getU16Codec}, {@link getU32Codec}, or {@link getU64Codec}.
+ * For signed integers, use {@link getI8Codec}.
+ *
+ * Separate {@link getU8Encoder} and {@link getU8Decoder} functions are available.
+ *
+ * ```ts
+ * const bytes = getU8Encoder().encode(42);
+ * const value = getU8Decoder().decode(bytes);
+ * ```
+ *
+ * @see {@link getU8Encoder}
+ * @see {@link getU8Decoder}
+ */
 export const getU8Codec = (): FixedSizeCodec<bigint | number, number, 1> =>
     combineCodec(getU8Encoder(), getU8Decoder());

--- a/packages/codecs-numbers/typedoc.json
+++ b/packages/codecs-numbers/typedoc.json
@@ -1,5 +1,6 @@
 {
     "$schema": "https://typedoc.org/schema.json",
     "extends": ["../typedoc.base.json"],
-    "entryPoints": ["src/index.ts"]
+    "entryPoints": ["src/index.ts"],
+    "readme": "none"
 }


### PR DESCRIPTION
This PR adds TypeDoc-compatible docblocks to all items inside the `codecs-numbers` package.

Addresses #50

# Test Plan

```shell
cd packages/codecs-numbers
pnpm typedoc --watch --plugin typedoc-plugin-missing-exports
python3 -m http.server -d docs
```

Preview here: https://boisterous-beijinho-89a951.netlify.app/