### PR TITLE
Document `@solana/codecs-data-structures` with TypeDoc

### DIFF
--- a/packages/codecs-data-structures/src/array.ts
+++ b/packages/codecs-data-structures/src/array.ts
@@ -20,35 +20,65 @@ import { assertValidNumberOfItemsForCodec } from './assertions';
 import { getFixedSize, getMaxSize } from './utils';
 
 /**
- * Represents all the size options for array-like codecs
- * — i.e. `array`, `map` and `set`.
+ * Defines the possible size strategies for array-like codecs (`array`, `map`, and `set`).
  *
- * It can be one of the following:
- * - a {@link NumberCodec} that prefixes its content with its size.
- * - a fixed number of items.
- * - or `'remainder'` to infer the number of items by dividing
- *   the rest of the byte array by the fixed size of its item.
- *   Note that this option is only available for fixed-size items.
+ * The size of the collection can be determined using one of the following approaches:
+ * - A {@link NumberCodec}, {@link NumberDecoder}, or {@link NumberEncoder} to store a size prefix.
+ * - A fixed `number` of items, enforcing an exact length.
+ * - The string `"remainder"`, which infers the number of items by consuming the rest of the available bytes.
+ *   This option is only available when encoding fixed-size items.
+ *
+ * @typeParam TPrefix - A number codec, decoder, or encoder used for size prefixing.
  */
 export type ArrayLikeCodecSize<TPrefix extends NumberCodec | NumberDecoder | NumberEncoder> =
     | TPrefix
     | number
     | 'remainder';
 
-/** Defines the configs for array codecs. */
+/**
+ * Defines the configuration options for array codecs.
+ *
+ * @typeParam TPrefix - A number codec, decoder, or encoder used for size prefixing.
+ */
 export type ArrayCodecConfig<TPrefix extends NumberCodec | NumberDecoder | NumberEncoder> = {
     /**
-     * The size of the array.
-     * @defaultValue u32 prefix.
+     * Specifies how the size of the array is determined.
+     *
+     * - A {@link NumberCodec}, {@link NumberDecoder}, or {@link NumberEncoder} stores a size prefix before encoding the array.
+     * - A `number` enforces a fixed number of elements.
+     * - `"remainder"` uses all remaining bytes to infer the array length (only for fixed-size items).
+     *
+     * @defaultValue A `u32` size prefix.
      */
     size?: ArrayLikeCodecSize<TPrefix>;
 };
 
 /**
- * Encodes an array of items.
+ * Returns an encoder for arrays of values.
  *
- * @param item - The encoder to use for the array's items.
- * @param config - A set of config for the encoder.
+ * This encoder serializes arrays by encoding each element using the provided item encoder.
+ * By default, a `u32` size prefix is included to indicate the number of items in the array.
+ * The `size` option can be used to modify this behaviour.
+ *
+ * For more details, see {@link getArrayCodec}.
+ *
+ * @typeParam TFrom - The type of the elements in the array.
+ *
+ * @param item - The encoder for each item in the array.
+ * @param config - Optional configuration for the size encoding strategy.
+ * @returns A `VariableSizeEncoder<TFrom[]>` for encoding arrays.
+ *
+ * @example
+ * Encoding an array of `u8` numbers.
+ * ```ts
+ * const encoder = getArrayEncoder(getU8Encoder());
+ * const bytes = encoder.encode([1, 2, 3]);
+ * // 0x03000000010203
+ * //   |       └-- 3 items of 1 byte each.
+ * //   └-- 4-byte prefix telling us to read 3 items.
+ * ```
+ *
+ * @see {@link getArrayCodec}
  */
 export function getArrayEncoder<TFrom>(
     item: Encoder<TFrom>,
@@ -96,10 +126,32 @@ export function getArrayEncoder<TFrom>(
 }
 
 /**
- * Decodes an array of items.
+ * Returns a decoder for arrays of values.
  *
- * @param item - The encoder to use for the array's items.
- * @param config - A set of config for the encoder.
+ * This decoder deserializes arrays by decoding each element using the provided item decoder.
+ * By default, a `u32` size prefix is expected to indicate the number of items in the array.
+ * The `size` option can be used to modify this behaviour.
+ *
+ * For more details, see {@link getArrayCodec}.
+ *
+ * @typeParam TTo - The type of the decoded elements in the array.
+ *
+ * @param item - The decoder for each item in the array.
+ * @param config - Optional configuration for the size decoding strategy.
+ * @returns A `VariableSizeDecoder<TTo[]>` for decoding arrays.
+ *
+ * @example
+ * Decoding an array of `u8` numbers.
+ * ```ts
+ * const decoder = getArrayDecoder(getU8Decoder());
+ * const array = decoder.decode(new Uint8Array([0x03, 0x00, 0x00, 0x00, 0x01, 0x02, 0x03]));
+ * // [1, 2, 3]
+ * // 0x03000000010203
+ * //   |       └-- 3 items of 1 byte each.
+ * //   └-- 4-byte prefix telling us to read 3 items.
+ * ```
+ *
+ * @see {@link getArrayCodec}
  */
 export function getArrayDecoder<TTo>(
     item: Decoder<TTo>,
@@ -149,10 +201,75 @@ export function getArrayDecoder<TTo>(item: Decoder<TTo>, config: ArrayCodecConfi
 }
 
 /**
- * Creates a codec for an array of items.
+ * Returns a codec for encoding and decoding arrays of values.
  *
- * @param item - The codec to use for the array's items.
- * @param config - A set of config for the codec.
+ * This codec serializes arrays by encoding each element using the provided item codec.
+ * By default, a `u32` size prefix is included to indicate the number of items in the array.
+ * The `size` option can be used to modify this behaviour.
+ *
+ * @typeParam TFrom - The type of the elements to encode.
+ * @typeParam TTo - The type of the decoded elements.
+ *
+ * @param item - The codec for each item in the array.
+ * @param config - Optional configuration for the size encoding/decoding strategy.
+ * @returns A `VariableSizeCodec<TFrom[], TTo[]>` for encoding and decoding arrays.
+ *
+ * @example
+ * Encoding and decoding an array of `u8` numbers.
+ * ```ts
+ * const codec = getArrayCodec(getU8Codec());
+ * const bytes = codec.encode([1, 2, 3]);
+ * // 0x03000000010203
+ * //   |       └-- 3 items of 1 byte each.
+ * //   └-- 4-byte prefix telling us to read 3 items.
+ *
+ * const array = codec.decode(bytes);
+ * // [1, 2, 3]
+ * ```
+ *
+ * @example
+ * Using a `u16` size prefix instead of `u32`.
+ * ```ts
+ * const codec = getArrayCodec(getU8Codec(), { size: getU16Codec() });
+ * const bytes = codec.encode([1, 2, 3]);
+ * // 0x0300010203
+ * //   |   └-- 3 items of 1 byte each.
+ * //   └-- 2-byte prefix telling us to read 3 items.
+ * ```
+ *
+ * @example
+ * Using a fixed-size array of 3 items.
+ * ```ts
+ * const codec = getArrayCodec(getU8Codec(), { size: 3 });
+ * codec.encode([1, 2, 3]);
+ * // 0x010203
+ * //   └-- 3 items of 1 byte each. There must always be 3 items in the array.
+ * ```
+ *
+ * @example
+ * Using the `"remainder"` size strategy.
+ * ```ts
+ * const codec = getArrayCodec(getU8Codec(), { size: 'remainder' });
+ * codec.encode([1, 2, 3]);
+ * // 0x010203
+ * //   └-- 3 items of 1 byte each. The size is inferred from the remainder of the bytes.
+ * ```
+ *
+ * @remarks
+ * The size of the array can be controlled using the `size` option:
+ * - A `Codec<number>` (e.g. `getU16Codec()`) stores a size prefix before the array.
+ * - A `number` enforces a fixed number of elements.
+ * - `"remainder"` uses all remaining bytes to infer the array length.
+ *
+ * Separate {@link getArrayEncoder} and {@link getArrayDecoder} functions are available.
+ *
+ * ```ts
+ * const bytes = getArrayEncoder(getU8Encoder()).encode([1, 2, 3]);
+ * const array = getArrayDecoder(getU8Decoder()).decode(bytes);
+ * ```
+ *
+ * @see {@link getArrayEncoder}
+ * @see {@link getArrayDecoder}
  */
 export function getArrayCodec<TFrom, TTo extends TFrom = TFrom>(
     item: Codec<TFrom, TTo>,

--- a/packages/codecs-data-structures/src/bit-array.ts
+++ b/packages/codecs-data-structures/src/bit-array.ts
@@ -8,20 +8,55 @@ import {
     FixedSizeEncoder,
 } from '@solana/codecs-core';
 
-/** Defines the config for bitArray codecs. */
+/**
+ * Defines the configuration options for bit array codecs.
+ *
+ * A bit array codec encodes an array of booleans into bits, packing them into bytes.
+ * This configuration allows adjusting the bit ordering.
+ *
+ * @see {@link getBitArrayEncoder}
+ * @see {@link getBitArrayDecoder}
+ * @see {@link getBitArrayCodec}
+ */
 export type BitArrayCodecConfig = {
     /**
-     * Whether to read the bits in reverse order.
+     * Determines whether the bits should be read in reverse order.
+     *
+     * - `false` (default): The first boolean is stored in the most significant bit (MSB-first).
+     * - `true`: The first boolean is stored in the least significant bit (LSB-first).
+     *
      * @defaultValue `false`
      */
     backward?: boolean;
 };
 
 /**
- * Encodes an array of booleans into bits.
+ * Returns an encoder that packs an array of booleans into bits.
  *
- * @param size - The amount of bytes to use for the bit array.
- * @param config - A set of config for the encoder.
+ * This encoder converts a list of `boolean` values into a compact bit representation,
+ * storing 8 booleans per byte.
+ *
+ * The `backward` config option determines whether the bits are stored in MSB-first (`false`)
+ * or LSB-first (`true`).
+ *
+ * For more details, see {@link getBitArrayCodec}.
+ *
+ * @typeParam TSize - The number of bytes used to store the bit array.
+ *
+ * @param size - The number of bytes allocated for the bit array (must be sufficient for the expected boolean count).
+ * @param config - Configuration options for encoding the bit array.
+ * @returns A `FixedSizeEncoder<boolean[], TSize>` for encoding bit arrays.
+ *
+ * @example
+ * Encoding a bit array.
+ * ```ts
+ * const encoder = getBitArrayEncoder(1);
+ *
+ * encoder.encode([true, false, true, false, false, false, false, false]);
+ * // 0xa0 (0b10100000)
+ * ```
+ *
+ * @see {@link getBitArrayCodec}
  */
 export function getBitArrayEncoder<TSize extends number>(
     size: TSize,
@@ -54,10 +89,32 @@ export function getBitArrayEncoder<TSize extends number>(
 }
 
 /**
- * Decodes bits into an array of booleans.
+ * Returns a decoder that unpacks bits into an array of booleans.
  *
- * @param size - The amount of bytes to use for the bit array.
- * @param config - A set of config for the decoder.
+ * This decoder converts a compact bit representation back into a list of `boolean` values.
+ * Each byte is expanded into 8 booleans.
+ *
+ * The `backward` config option determines whether the bits are read in MSB-first (`false`)
+ * or LSB-first (`true`).
+ *
+ * For more details, see {@link getBitArrayCodec}.
+ *
+ * @typeParam TSize - The number of bytes used to store the bit array.
+ *
+ * @param size - The number of bytes allocated for the bit array (must be sufficient for the expected boolean count).
+ * @param config - Configuration options for decoding the bit array.
+ * @returns A `FixedSizeDecoder<boolean[], TSize>` for decoding bit arrays.
+ *
+ * @example
+ * Decoding a bit array.
+ * ```ts
+ * const decoder = getBitArrayDecoder(1);
+ *
+ * decoder.decode(new Uint8Array([0xa0]));
+ * // [true, false, true, false, false, false, false, false]
+ * ```
+ *
+ * @see {@link getBitArrayCodec}
  */
 export function getBitArrayDecoder<TSize extends number>(
     size: TSize,
@@ -91,10 +148,52 @@ export function getBitArrayDecoder<TSize extends number>(
 }
 
 /**
- * An array of boolean codec that converts booleans to bits and vice versa.
+ * Returns a codec that encodes and decodes boolean arrays as compact bit representations.
  *
- * @param size - The amount of bytes to use for the bit array.
- * @param config - A set of config for the codec.
+ * This codec efficiently stores boolean arrays as bits, packing 8 values per byte.
+ * The `backward` config option determines whether bits are stored in MSB-first (`false`)
+ * or LSB-first (`true`).
+ *
+ * @typeParam TSize - The number of bytes used to store the bit array.
+ *
+ * @param size - The number of bytes allocated for the bit array (must be sufficient for the expected boolean count).
+ * @param config - Configuration options for encoding and decoding the bit array.
+ * @returns A `FixedSizeCodec<boolean[], boolean[], TSize>` for encoding and decoding bit arrays.
+ *
+ * @example
+ * Encoding and decoding a bit array.
+ * ```ts
+ * const codec = getBitArrayCodec(1);
+ *
+ * codec.encode([true, false, true, false, false, false, false, false]);
+ * // 0xa0 (0b10100000)
+ *
+ * codec.decode(new Uint8Array([0xa0]));
+ * // [true, false, true, false, false, false, false, false]
+ * ```
+ *
+ * @example
+ * Encoding and decoding a bit array backwards.
+ * ```ts
+ * const codec = getBitArrayCodec(1, { backward: true });
+ *
+ * codec.encode([true, false, true, false, false, false, false, false]);
+ * // 0x05 (0b00000101)
+ *
+ * codec.decode(new Uint8Array([0x05]));
+ * // [true, false, true, false, false, false, false, false]
+ * ```
+ *
+ * @remarks
+ * Separate {@link getBitArrayEncoder} and {@link getBitArrayDecoder} functions are available.
+ *
+ * ```ts
+ * const bytes = getBitArrayEncoder(1).encode([true, false, true, false]);
+ * const value = getBitArrayDecoder(1).decode(bytes);
+ * ```
+ *
+ * @see {@link getBitArrayEncoder}
+ * @see {@link getBitArrayDecoder}
  */
 export function getBitArrayCodec<TSize extends number>(
     size: TSize,

--- a/packages/codecs-data-structures/src/boolean.ts
+++ b/packages/codecs-data-structures/src/boolean.ts
@@ -23,19 +23,51 @@ import {
     NumberEncoder,
 } from '@solana/codecs-numbers';
 
-/** Defines the config for boolean codecs. */
+/**
+ * Defines the configuration options for boolean codecs.
+ *
+ * A boolean codec encodes `true` as `1` and `false` as `0`.
+ * The `size` option allows customizing the number codec used for storage.
+ *
+ * @typeParam TSize - A number codec, encoder, or decoder used for boolean representation.
+ *
+ * @see {@link getBooleanEncoder}
+ * @see {@link getBooleanDecoder}
+ * @see {@link getBooleanCodec}
+ */
 export type BooleanCodecConfig<TSize extends NumberCodec | NumberDecoder | NumberEncoder> = {
     /**
-     * The number codec to delegate to.
-     * @defaultValue u8 size.
+     * The number codec used to store boolean values.
+     *
+     * - By default, booleans are stored as a `u8` (`1` for `true`, `0` for `false`).
+     * - A custom number codec can be provided to change the storage size.
+     *
+     * @defaultValue `u8`
      */
     size?: TSize;
 };
 
 /**
- * Encodes booleans.
+ * Returns an encoder for boolean values.
  *
- * @param config - A set of config for the encoder.
+ * This encoder converts `true` into `1` and `false` into `0`.
+ * The `size` option allows customizing the number codec used for storage.
+ *
+ * For more details, see {@link getBooleanCodec}.
+ *
+ * @param config - Configuration options for encoding booleans.
+ * @returns A `FixedSizeEncoder<boolean, N>` where `N` is the size of the number codec.
+ *
+ * @example
+ * Encoding booleans.
+ * ```ts
+ * const encoder = getBooleanEncoder();
+ *
+ * encoder.encode(false); // 0x00
+ * encoder.encode(true);  // 0x01
+ * ```
+ *
+ * @see {@link getBooleanCodec}
  */
 export function getBooleanEncoder(): FixedSizeEncoder<boolean, 1>;
 export function getBooleanEncoder<TSize extends number>(
@@ -47,9 +79,26 @@ export function getBooleanEncoder(config: BooleanCodecConfig<NumberEncoder> = {}
 }
 
 /**
- * Decodes booleans.
+ * Returns a decoder for boolean values.
  *
- * @param config - A set of config for the decoder.
+ * This decoder reads a number and interprets `1` as `true` and `0` as `false`.
+ * The `size` option allows customizing the number codec used for storage.
+ *
+ * For more details, see {@link getBooleanCodec}.
+ *
+ * @param config - Configuration options for decoding booleans.
+ * @returns A `FixedSizeDecoder<boolean, N>` where `N` is the size of the number codec.
+ *
+ * @example
+ * Decoding booleans.
+ * ```ts
+ * const decoder = getBooleanDecoder();
+ *
+ * decoder.decode(new Uint8Array([0x00])); // false
+ * decoder.decode(new Uint8Array([0x01])); // true
+ * ```
+ *
+ * @see {@link getBooleanCodec}
  */
 export function getBooleanDecoder(): FixedSizeDecoder<boolean, 1>;
 export function getBooleanDecoder<TSize extends number>(
@@ -61,9 +110,48 @@ export function getBooleanDecoder(config: BooleanCodecConfig<NumberDecoder> = {}
 }
 
 /**
- * Creates a boolean codec.
+ * Returns a codec for encoding and decoding boolean values.
  *
- * @param config - A set of config for the codec.
+ * By default, booleans are stored as a `u8` (`1` for `true`, `0` for `false`).
+ * The `size` option allows customizing the number codec used for storage.
+ *
+ * @param config - Configuration options for encoding and decoding booleans.
+ * @returns A `FixedSizeCodec<boolean, boolean, N>` where `N` is the size of the number codec.
+ *
+ * @example
+ * Encoding and decoding booleans using a `u8` (default).
+ * ```ts
+ * const codec = getBooleanCodec();
+ *
+ * codec.encode(false); // 0x00
+ * codec.encode(true);  // 0x01
+ *
+ * codec.decode(new Uint8Array([0x00])); // false
+ * codec.decode(new Uint8Array([0x01])); // true
+ * ```
+ *
+ * @example
+ * Encoding and decoding booleans using a custom number codec.
+ * ```ts
+ * const codec = getBooleanCodec({ size: getU16Codec() });
+ *
+ * codec.encode(false); // 0x0000
+ * codec.encode(true);  // 0x0100
+ *
+ * codec.decode(new Uint8Array([0x00, 0x00])); // false
+ * codec.decode(new Uint8Array([0x01, 0x00])); // true
+ * ```
+ *
+ * @remarks
+ * Separate {@link getBooleanEncoder} and {@link getBooleanDecoder} functions are available.
+ *
+ * ```ts
+ * const bytes = getBooleanEncoder().encode(true);
+ * const value = getBooleanDecoder().decode(bytes);
+ * ```
+ *
+ * @see {@link getBooleanEncoder}
+ * @see {@link getBooleanDecoder}
  */
 export function getBooleanCodec(): FixedSizeCodec<boolean, boolean, 1>;
 export function getBooleanCodec<TSize extends number>(

--- a/packages/codecs-data-structures/src/bytes.ts
+++ b/packages/codecs-data-structures/src/bytes.ts
@@ -9,10 +9,29 @@ import {
 } from '@solana/codecs-core';
 
 /**
- * Encodes byte arrays as provided.
+ * Returns an encoder for raw byte arrays.
  *
- * To control the size of the encoded byte array, you can use
- * the `fixEncoderSize` or `addEncoderSizePrefix` functions.
+ * This encoder writes byte arrays exactly as provided without modification.
+ *
+ * The size of the encoded byte array is determined by the length of the input.
+ * - To enforce a fixed size, consider using {@link fixEncoderSize}.
+ * - To add a size prefix, use {@link addEncoderSizePrefix}.
+ * - To add a sentinel value, use {@link addEncoderSentinel}.
+ *
+ * For more details, see {@link getBytesCodec}.
+ *
+ * @returns A `VariableSizeEncoder<ReadonlyUint8Array | Uint8Array>`.
+ *
+ * @example
+ * Encoding a byte array as-is.
+ * ```ts
+ * const encoder = getBytesEncoder();
+ *
+ * encoder.encode(new Uint8Array([1, 2, 3])); // 0x010203
+ * encoder.encode(new Uint8Array([255, 0, 127])); // 0xff007f
+ * ```
+ *
+ * @see {@link getBytesCodec}
  */
 export function getBytesEncoder(): VariableSizeEncoder<ReadonlyUint8Array | Uint8Array> {
     return createEncoder({
@@ -25,10 +44,29 @@ export function getBytesEncoder(): VariableSizeEncoder<ReadonlyUint8Array | Uint
 }
 
 /**
- * Decodes byte arrays as-is.
+ * Returns a decoder for raw byte arrays.
  *
- * To control the size of the decoded byte array, you can use
- * the `fixDecoderSize` or `addDecoderSizePrefix` functions.
+ * This decoder reads byte arrays exactly as provided without modification.
+ *
+ * The decoded byte array extends from the provided offset to the end of the input.
+ * - To enforce a fixed size, consider using {@link fixDecoderSize}.
+ * - To add a size prefix, use {@link addDecoderSizePrefix}.
+ * - To add a sentinel value, use {@link addDecoderSentinel}.
+ *
+ * For more details, see {@link getBytesCodec}.
+ *
+ * @returns A `VariableSizeDecoder<ReadonlyUint8Array>`.
+ *
+ * @example
+ * Decoding a byte array as-is.
+ * ```ts
+ * const decoder = getBytesDecoder();
+ *
+ * decoder.decode(new Uint8Array([1, 2, 3])); // Uint8Array([1, 2, 3])
+ * decoder.decode(new Uint8Array([255, 0, 127])); // Uint8Array([255, 0, 127])
+ * ```
+ *
+ * @see {@link getBytesCodec}
  */
 export function getBytesDecoder(): VariableSizeDecoder<ReadonlyUint8Array> {
     return createDecoder({
@@ -40,10 +78,37 @@ export function getBytesDecoder(): VariableSizeDecoder<ReadonlyUint8Array> {
 }
 
 /**
- * Creates a sized bytes codec.
+ * Returns a codec for encoding and decoding raw byte arrays.
  *
- * To control the size of the encoded and decoded byte arrays,
- * you can use the `fixCodecSize` or `addCodecSizePrefix` functions.
+ * This codec serializes and deserializes byte arrays without modification.
+ *
+ * The size of the encoded and decoded byte array is determined dynamically.
+ * This means, when reading, the codec will consume all remaining bytes in the input.
+ * - To enforce a fixed size, consider using {@link fixCodecSize}.
+ * - To add a size prefix, use {@link addCodecSizePrefix}.
+ * - To add a sentinel value, use {@link addCodecSentinel}.
+ *
+ * @returns A `VariableSizeCodec<ReadonlyUint8Array | Uint8Array, ReadonlyUint8Array>`.
+ *
+ * @example
+ * Encoding and decoding a byte array.
+ * ```ts
+ * const codec = getBytesCodec();
+ *
+ * codec.encode(new Uint8Array([1, 2, 3])); // 0x010203
+ * codec.decode(new Uint8Array([255, 0, 127])); // Uint8Array([255, 0, 127])
+ * ```
+ *
+ * @remarks
+ * Separate {@link getBytesEncoder} and {@link getBytesDecoder} functions are available.
+ *
+ * ```ts
+ * const bytes = getBytesEncoder().encode(new Uint8Array([1, 2, 3]));
+ * const value = getBytesDecoder().decode(bytes);
+ * ```
+ *
+ * @see {@link getBytesEncoder}
+ * @see {@link getBytesDecoder}
  */
 export function getBytesCodec(): VariableSizeCodec<ReadonlyUint8Array | Uint8Array, ReadonlyUint8Array> {
     return combineCodec(getBytesEncoder(), getBytesDecoder());

--- a/packages/codecs-data-structures/src/constant.ts
+++ b/packages/codecs-data-structures/src/constant.ts
@@ -12,7 +12,29 @@ import { getBase16Decoder } from '@solana/codecs-strings';
 import { SOLANA_ERROR__CODECS__INVALID_CONSTANT, SolanaError } from '@solana/errors';
 
 /**
- * Creates a void encoder that always sets the provided byte array when encoding.
+ * Returns an encoder that always writes a predefined constant byte sequence.
+ *
+ * This encoder ensures that encoding always produces the specified byte array,
+ * ignoring any input values.
+ *
+ * For more details, see {@link getConstantCodec}.
+ *
+ * @typeParam TConstant - The fixed byte sequence that will be written during encoding.
+ *
+ * @param constant - The predefined byte array to encode.
+ * @returns A `FixedSizeEncoder<void, N>` where `N` is the length of the constant.
+ *
+ * @example
+ * Encoding a constant magic number.
+ * ```ts
+ * const encoder = getConstantEncoder(new Uint8Array([1, 2, 3, 4]));
+ *
+ * const bytes = encoder.encode();
+ * // 0x01020304
+ * //   └──────┘ The predefined 4-byte constant.
+ * ```
+ *
+ * @see {@link getConstantCodec}
  */
 export function getConstantEncoder<TConstant extends ReadonlyUint8Array>(
     constant: TConstant,
@@ -27,7 +49,28 @@ export function getConstantEncoder<TConstant extends ReadonlyUint8Array>(
 }
 
 /**
- * Creates a void decoder that reads the next bytes and fails if they do not match the provided constant.
+ * Returns a decoder that verifies a predefined constant byte sequence.
+ *
+ * This decoder reads the next bytes and checks that they match the provided constant.
+ * If the bytes differ, it throws an error.
+ *
+ * For more details, see {@link getConstantCodec}.
+ *
+ * @typeParam TConstant - The fixed byte sequence expected during decoding.
+ *
+ * @param constant - The predefined byte array to verify.
+ * @returns A `FixedSizeDecoder<void, N>` where `N` is the length of the constant.
+ *
+ * @example
+ * Decoding a constant magic number.
+ * ```ts
+ * const decoder = getConstantDecoder(new Uint8Array([1, 2, 3]));
+ *
+ * decoder.decode(new Uint8Array([1, 2, 3])); // Passes
+ * decoder.decode(new Uint8Array([1, 2, 4])); // Throws an error
+ * ```
+ *
+ * @see {@link getConstantCodec}
  */
 export function getConstantDecoder<TConstant extends ReadonlyUint8Array>(
     constant: TConstant,
@@ -51,9 +94,39 @@ export function getConstantDecoder<TConstant extends ReadonlyUint8Array>(
 }
 
 /**
- * Creates a void codec that always sets the provided byte array
- * when encoding and, when decoding, asserts that the next
- * bytes match the provided byte array.
+ * Returns a codec that encodes and decodes a predefined constant byte sequence.
+ *
+ * - **Encoding:** Always writes the specified byte array.
+ * - **Decoding:** Asserts that the next bytes match the constant, throwing an error if they do not.
+ *
+ * This is useful for encoding fixed byte patterns required in a binary format or to use in
+ * conjunction with other codecs such as {@link getHiddenPrefixCodec} or {@link getHiddenSuffixCodec}.
+ *
+ * @typeParam TConstant - The fixed byte sequence to encode and verify during decoding.
+ *
+ * @param constant - The predefined byte array to encode and assert during decoding.
+ * @returns A `FixedSizeCodec<void, void, N>` where `N` is the length of the constant.
+ *
+ * @example
+ * Encoding and decoding a constant magic number.
+ * ```ts
+ * const codec = getConstantCodec(new Uint8Array([1, 2, 3]));
+ *
+ * codec.encode(); // 0x010203
+ * codec.decode(new Uint8Array([1, 2, 3])); // Passes
+ * codec.decode(new Uint8Array([1, 2, 4])); // Throws an error
+ * ```
+ *
+ * @remarks
+ * Separate {@link getConstantEncoder} and {@link getConstantDecoder} functions are available.
+ *
+ * ```ts
+ * const bytes = getConstantEncoder(new Uint8Array([1, 2, 3])).encode();
+ * getConstantDecoder(new Uint8Array([1, 2, 3])).decode(bytes);
+ * ```
+ *
+ * @see {@link getConstantEncoder}
+ * @see {@link getConstantDecoder}
  */
 export function getConstantCodec<TConstant extends ReadonlyUint8Array>(
     constant: TConstant,

--- a/packages/codecs-data-structures/src/discriminated-union.ts
+++ b/packages/codecs-data-structures/src/discriminated-union.ts
@@ -8,13 +8,20 @@ import { getUnionDecoder, getUnionEncoder } from './union';
 import { DrainOuterGeneric } from './utils';
 
 /**
- * Defines a discriminated union using discriminated union types.
+ * Represents a discriminated union using a specific discriminator property.
+ *
+ * A discriminated union is a TypeScript-friendly way to represent Rust-like enums.
+ * Each variant in the union is distinguished by a shared discriminator property.
+ *
+ * @typeParam TDiscriminatorProperty - The name of the discriminator property.
+ * @typeParam TDiscriminatorValue - The type of the discriminator value.
  *
  * @example
  * ```ts
- * type WebPageEvent =
- *   | { __kind: 'pageview', url: string }
- *   | { __kind: 'click', x: number, y: number };
+ * type Message =
+ *   | { __kind: 'Quit' } // Empty variant
+ *   | { __kind: 'Write'; fields: [string] } // Tuple variant
+ *   | { __kind: 'Move'; x: number; y: number }; // Struct variant
  * ```
  */
 export type DiscriminatedUnion<
@@ -25,15 +32,21 @@ export type DiscriminatedUnion<
 };
 
 /**
- * Extracts a variant from a discriminated union.
+ * Extracts a variant from a discriminated union based on its discriminator value.
+ *
+ * @typeParam TUnion - The discriminated union type.
+ * @typeParam TDiscriminatorProperty - The property used as the discriminator.
+ * @typeParam TDiscriminatorValue - The specific variant to extract.
  *
  * @example
  * ```ts
- * type WebPageEvent =
- *   | { __kind: 'pageview', url: string }
- *   | { __kind: 'click', x: number, y: number };
- * type ClickEvent = GetDiscriminatedUnionVariant<WebPageEvent, '__kind', 'click'>;
- * // -> { __kind: 'click', x: number, y: number }
+ * type Message =
+ *   | { __kind: 'Quit' }
+ *   | { __kind: 'Write'; fields: [string] }
+ *   | { __kind: 'Move'; x: number; y: number };
+ *
+ * type ClickEvent = GetDiscriminatedUnionVariant<Message, '__kind', 'Move'>;
+ * // -> { __kind: 'Move'; x: number; y: number }
  * ```
  */
 export type GetDiscriminatedUnionVariant<
@@ -43,15 +56,21 @@ export type GetDiscriminatedUnionVariant<
 > = Extract<TUnion, DiscriminatedUnion<TDiscriminatorProperty, TDiscriminatorValue>>;
 
 /**
- * Extracts a variant from a discriminated union without its discriminator.
+ * Extracts a variant from a discriminated union without its discriminator property.
+ *
+ * @typeParam TUnion - The discriminated union type.
+ * @typeParam TDiscriminatorProperty - The property used as the discriminator.
+ * @typeParam TDiscriminatorValue - The specific variant to extract.
  *
  * @example
  * ```ts
- * type WebPageEvent =
- *   | { __kind: 'pageview', url: string }
- *   | { __kind: 'click', x: number, y: number };
- * type ClickEvent = GetDiscriminatedUnionVariantContent<WebPageEvent, '__kind', 'click'>;
- * // -> { x: number, y: number }
+ * type Message =
+ *   | { __kind: 'Quit' }
+ *   | { __kind: 'Write'; fields: [string] }
+ *   | { __kind: 'Move'; x: number; y: number };
+ *
+ * type MoveContent = GetDiscriminatedUnionVariantContent<Message, '__kind', 'Move'>;
+ * // -> { x: number; y: number }
  * ```
  */
 export type GetDiscriminatedUnionVariantContent<
@@ -60,19 +79,26 @@ export type GetDiscriminatedUnionVariantContent<
     TDiscriminatorValue extends TUnion[TDiscriminatorProperty],
 > = Omit<GetDiscriminatedUnionVariant<TUnion, TDiscriminatorProperty, TDiscriminatorValue>, TDiscriminatorProperty>;
 
-/** Defines the config for discriminated union codecs. */
+/**
+ * Defines the configuration for discriminated union codecs.
+ *
+ * This configuration controls how the discriminator is stored and named.
+ *
+ * @typeParam TDiscriminatorProperty - The property name of the discriminator.
+ * @typeParam TDiscriminatorSize - The codec used for the discriminator prefix.
+ */
 export type DiscriminatedUnionCodecConfig<
     TDiscriminatorProperty extends string = '__kind',
     TDiscriminatorSize = NumberCodec | NumberDecoder | NumberEncoder,
 > = {
     /**
      * The property name of the discriminator.
-     * @defaultValue `__kind`.
+     * @defaultValue `__kind`
      */
     discriminator?: TDiscriminatorProperty;
     /**
-     * The codec to use for the enum discriminator prefixing the variant.
-     * @defaultValue u8 prefix.
+     * The codec used to encode/decode the discriminator prefix.
+     * @defaultValue `u8` prefix
      */
     size?: TDiscriminatorSize;
 };
@@ -104,10 +130,45 @@ type GetDecoderTypeFromVariants<
 }>[ArrayIndices<TVariants>];
 
 /**
- * Creates a discriminated union encoder.
+ * Returns an encoder for discriminated unions.
  *
- * @param variants - The variant encoders of the discriminated union.
- * @param config - A set of config for the encoder.
+ * This encoder serializes objects that follow the discriminated union pattern
+ * by prefixing them with a numerical discriminator that represents their variant.
+ *
+ * Unlike {@link getUnionEncoder}, this encoder automatically extracts and processes
+ * the discriminator property (default: `__kind`) from each variant.
+ *
+ * For more details, see {@link getDiscriminatedUnionCodec}.
+ *
+ * @typeParam TVariants - The variants of the discriminated union.
+ * @typeParam TDiscriminatorProperty - The property used as the discriminator.
+ *
+ * @param variants - The variant encoders as `[discriminator, encoder]` pairs.
+ * @param config - Configuration options for encoding.
+ * @returns An `Encoder` for encoding discriminated union objects.
+ *
+ * @example
+ * Encoding a discriminated union.
+ * ```ts
+ * type Message =
+ *   | { __kind: 'Quit' } // Empty variant.
+ *   | { __kind: 'Write'; fields: [string] } // Tuple variant.
+ *   | { __kind: 'Move'; x: number; y: number }; // Struct variant.
+ *
+ * const messageEncoder = getDiscriminatedUnionEncoder([
+ *   ['Quit', getUnitEncoder()],
+ *   ['Write', getStructEncoder([['fields', getTupleEncoder([addCodecSizePrefix(getUtf8Encoder(), getU32Encoder())])]])],
+ *   ['Move', getStructEncoder([['x', getI32Encoder()], ['y', getI32Encoder()]])]
+ * ]);
+ *
+ * messageEncoder.encode({ __kind: 'Move', x: 5, y: 6 });
+ * // 0x020500000006000000
+ * //   | |       └── Field y (6)
+ * //   | └── Field x (5)
+ * //   └── 1-byte discriminator (Index 2 — the "Move" variant)
+ * ```
+ *
+ * @see {@link getDiscriminatedUnionCodec}
  */
 export function getDiscriminatedUnionEncoder<
     const TVariants extends Variants<Encoder<any>>,
@@ -128,10 +189,42 @@ export function getDiscriminatedUnionEncoder<
 }
 
 /**
- * Creates a discriminated union decoder.
+ * Returns a decoder for discriminated unions.
  *
- * @param variants - The variant decoders of the discriminated union.
- * @param config - A set of config for the decoder.
+ * This decoder deserializes objects that follow the discriminated union pattern
+ * by **reading a numerical discriminator** and mapping it to the corresponding variant.
+ *
+ * Unlike {@link getUnionDecoder}, this decoder automatically inserts the discriminator
+ * property (default: `__kind`) into the decoded object.
+ *
+ * For more details, see {@link getDiscriminatedUnionCodec}.
+ *
+ * @typeParam TVariants - The variants of the discriminated union.
+ * @typeParam TDiscriminatorProperty - The property used as the discriminator.
+ *
+ * @param variants - The variant decoders as `[discriminator, decoder]` pairs.
+ * @param config - Configuration options for decoding.
+ * @returns A `Decoder` for decoding discriminated union objects.
+ *
+ * @example
+ * Decoding a discriminated union.
+ * ```ts
+ * type Message =
+ *   | { __kind: 'Quit' } // Empty variant.
+ *   | { __kind: 'Write'; fields: [string] } // Tuple variant.
+ *   | { __kind: 'Move'; x: number; y: number }; // Struct variant.
+ *
+ * const messageDecoder = getDiscriminatedUnionDecoder([
+ *   ['Quit', getUnitDecoder()],
+ *   ['Write', getStructDecoder([['fields', getTupleDecoder([addCodecSizePrefix(getUtf8Decoder(), getU32Decoder())])]])],
+ *   ['Move', getStructDecoder([['x', getI32Decoder()], ['y', getI32Decoder()]])]
+ * ]);
+ *
+ * messageDecoder.decode(new Uint8Array([0x02,0x05,0x00,0x00,0x00,0x06,0x00,0x00,0x00]));
+ * // { __kind: 'Move', x: 5, y: 6 }
+ * ```
+ *
+ * @see {@link getDiscriminatedUnionCodec}
  */
 export function getDiscriminatedUnionDecoder<
     const TVariants extends Variants<Decoder<any>>,
@@ -154,10 +247,76 @@ export function getDiscriminatedUnionDecoder<
 }
 
 /**
- * Creates a discriminated union codec.
+ * Returns a codec for encoding and decoding {@link DiscriminatedUnion}.
  *
- * @param variants - The variant codecs of the discriminated union.
- * @param config - A set of config for the codec.
+ * A {@link DiscriminatedUnion} is a TypeScript representation of Rust-like enums, where
+ * each variant is distinguished by a discriminator field (default: `__kind`).
+ *
+ * This codec inserts a numerical prefix to represent the variant index.
+ *
+ * @typeParam TVariants - The variants of the discriminated union.
+ * @typeParam TDiscriminatorProperty - The property used as the discriminator.
+ *
+ * @param variants - The variant codecs as `[discriminator, codec]` pairs.
+ * @param config - Configuration options for encoding/decoding.
+ * @returns A `Codec` for encoding and decoding discriminated union objects.
+ *
+ * @example
+ * Encoding and decoding a discriminated union.
+ * ```ts
+ * type Message =
+ *   | { __kind: 'Quit' } // Empty variant.
+ *   | { __kind: 'Write'; fields: [string] } // Tuple variant.
+ *   | { __kind: 'Move'; x: number; y: number }; // Struct variant.
+ *
+ * const messageCodec = getDiscriminatedUnionCodec([
+ *   ['Quit', getUnitCodec()],
+ *   ['Write', getStructCodec([['fields', getTupleCodec([addCodecSizePrefix(getUtf8Codec(), getU32Codec())])]])],
+ *   ['Move', getStructCodec([['x', getI32Codec()], ['y', getI32Codec()]])]
+ * ]);
+ *
+ * messageCodec.encode({ __kind: 'Move', x: 5, y: 6 });
+ * // 0x020500000006000000
+ * //   | |       └── Field y (6)
+ * //   | └── Field x (5)
+ * //   └── 1-byte discriminator (Index 2 — the "Move" variant)
+ *
+ * const value = messageCodec.decode(bytes);
+ * // { __kind: 'Move', x: 5, y: 6 }
+ * ```
+ *
+ * @example
+ * Using a `u32` discriminator instead of `u8`.
+ * ```ts
+ * const codec = getDiscriminatedUnionCodec([...], { size: getU32Codec() });
+ *
+ * codec.encode({ __kind: 'Quit' });
+ * // 0x00000000
+ * //   └------┘ 4-byte discriminator (Index 0)
+ *
+ * codec.decode(new Uint8Array([0x00, 0x00, 0x00, 0x00]));
+ * // { __kind: 'Quit' }
+ * ```
+ *
+ * @example
+ * Customizing the discriminator property.
+ * ```ts
+ * const codec = getDiscriminatedUnionCodec([...], { discriminator: 'message' });
+ *
+ * codec.encode({ message: 'Quit' }); // 0x00
+ * codec.decode(new Uint8Array([0x00])); // { message: 'Quit' }
+ * ```
+ *
+ * @remarks
+ * Separate `getDiscriminatedUnionEncoder` and `getDiscriminatedUnionDecoder` functions are available.
+ *
+ * ```ts
+ * const bytes = getDiscriminatedUnionEncoder(variantEncoders).encode({ __kind: 'Quit' });
+ * const message = getDiscriminatedUnionDecoder(variantDecoders).decode(bytes);
+ * ```
+ *
+ * @see {@link getDiscriminatedUnionEncoder}
+ * @see {@link getDiscriminatedUnionDecoder}
  */
 export function getDiscriminatedUnionCodec<
     const TVariants extends Variants<Codec<any, any>>,

--- a/packages/codecs-data-structures/src/enum.ts
+++ b/packages/codecs-data-structures/src/enum.ts
@@ -39,27 +39,60 @@ import {
     GetEnumTo,
 } from './enum-helpers';
 
-/** Defines the config for enum codecs. */
+/**
+ * Defines the configuration options for enum codecs.
+ *
+ * The `size` option determines the numerical encoding used for the enum's discriminant.
+ * By default, enums are stored as a `u8` (1 byte).
+ *
+ * The `useValuesAsDiscriminators` option allows mapping the actual enum values
+ * as discriminators instead of using their positional index.
+ *
+ * @typeParam TDiscriminator - A number codec, encoder, or decoder used for the discriminant.
+ */
 export type EnumCodecConfig<TDiscriminator extends NumberCodec | NumberDecoder | NumberEncoder> = {
     /**
-     * The codec to use for the enum discriminator.
-     * @defaultValue u8 discriminator.
+     * The codec used to encode/decode the enum discriminator.
+     * @defaultValue `u8` discriminator.
      */
     size?: TDiscriminator;
 
     /**
-     * When set to `true`, numeric values will be used as discriminantors and
-     * an error will be thrown if a string value is found on the enum.
+     * If set to `true`, the enum values themselves will be used as discriminators.
+     * This is only valid for numerical enum values.
+     *
      * @defaultValue `false`
      */
     useValuesAsDiscriminators?: boolean;
 };
 
 /**
- * Creates an enum encoder.
+ * Returns an encoder for enums.
+ *
+ * This encoder serializes enums as a numerical discriminator.
+ * By default, the discriminator is based on the positional index of the enum variants.
+ *
+ * For more details, see {@link getEnumCodec}.
+ *
+ * @typeParam TEnum - The TypeScript enum or object mapping enum keys to values.
  *
  * @param constructor - The constructor of the enum.
- * @param config - A set of config for the encoder.
+ * @param config - Configuration options for encoding the enum.
+ * @returns A `FixedSizeEncoder` or `VariableSizeEncoder` for encoding enums.
+ *
+ * @example
+ * Encoding enum values.
+ * ```ts
+ * enum Direction { Up,  Down, Left, Right }
+ * const encoder = getEnumEncoder(Direction);
+ *
+ * encoder.encode(Direction.Up);    // 0x00
+ * encoder.encode(Direction.Down);  // 0x01
+ * encoder.encode(Direction.Left);  // 0x02
+ * encoder.encode(Direction.Right); // 0x03
+ * ```
+ *
+ * @see {@link getEnumCodec}
  */
 export function getEnumEncoder<TEnum extends EnumLookupObject>(
     constructor: TEnum,
@@ -100,10 +133,32 @@ export function getEnumEncoder<TEnum extends EnumLookupObject>(
 }
 
 /**
- * Creates an enum decoder.
+ * Returns a decoder for enums.
+ *
+ * This decoder deserializes enums from a numerical discriminator.
+ * By default, the discriminator is based on the positional index of the enum variants.
+ *
+ * For more details, see {@link getEnumCodec}.
+ *
+ * @typeParam TEnum - The TypeScript enum or object mapping enum keys to values.
  *
  * @param constructor - The constructor of the enum.
- * @param config - A set of config for the decoder.
+ * @param config - Configuration options for decoding the enum.
+ * @returns A `FixedSizeDecoder` or `VariableSizeDecoder` for decoding enums.
+ *
+ * @example
+ * Decoding enum values.
+ * ```ts
+ * enum Direction { Up,  Down, Left, Right }
+ * const decoder = getEnumDecoder(Direction);
+ *
+ * decoder.decode(new Uint8Array([0x00])); // Direction.Up
+ * decoder.decode(new Uint8Array([0x01])); // Direction.Down
+ * decoder.decode(new Uint8Array([0x02])); // Direction.Left
+ * decoder.decode(new Uint8Array([0x03])); // Direction.Right
+ * ```
+ *
+ * @see {@link getEnumCodec}
  */
 export function getEnumDecoder<TEnum extends EnumLookupObject>(
     constructor: TEnum,
@@ -152,10 +207,87 @@ export function getEnumDecoder<TEnum extends EnumLookupObject>(
 }
 
 /**
- * Creates an enum codec.
+ * Returns a codec for encoding and decoding enums.
+ *
+ * This codec serializes enums as a numerical discriminator, allowing them
+ * to be efficiently stored and reconstructed from binary data.
+ *
+ * By default, the discriminator is derived from the positional index
+ * of the enum variant, but it can be configured to use the enum's numeric values instead.
+ *
+ * @typeParam TEnum - The TypeScript enum or object mapping enum keys to values.
  *
  * @param constructor - The constructor of the enum.
- * @param config - A set of config for the codec.
+ * @param config - Configuration options for encoding and decoding the enum.
+ * @returns A `FixedSizeCodec` or `VariableSizeCodec` for encoding and decoding enums.
+ *
+ * @example
+ * Encoding and decoding enums using positional indexes.
+ * ```ts
+ * enum Direction { Up, Down, Left, Right }
+ * const codec = getEnumCodec(Direction);
+ *
+ * codec.encode(Direction.Up);    // 0x00
+ * codec.encode(Direction.Down);  // 0x01
+ * codec.encode(Direction.Left);  // 0x02
+ * codec.encode(Direction.Right); // 0x03
+ *
+ * codec.decode(new Uint8Array([0x00])); // Direction.Up
+ * codec.decode(new Uint8Array([0x01])); // Direction.Down
+ * codec.decode(new Uint8Array([0x02])); // Direction.Left
+ * codec.decode(new Uint8Array([0x03])); // Direction.Right
+ * ```
+ *
+ * @example
+ * Encoding and decoding enums using their numeric values.
+ * ```ts
+ * enum GameDifficulty { Easy = 1, Normal = 4, Hard = 7, Expert = 9 }
+ * const codec = getEnumCodec(GameDifficulty, { useValuesAsDiscriminators: true });
+ *
+ * codec.encode(GameDifficulty.Easy);   // 0x01
+ * codec.encode(GameDifficulty.Normal); // 0x04
+ * codec.encode(GameDifficulty.Hard);   // 0x07
+ * codec.encode(GameDifficulty.Expert); // 0x09
+ *
+ * codec.decode(new Uint8Array([0x01])); // GameDifficulty.Easy
+ * codec.decode(new Uint8Array([0x04])); // GameDifficulty.Normal
+ * codec.decode(new Uint8Array([0x07])); // GameDifficulty.Hard
+ * codec.decode(new Uint8Array([0x09])); // GameDifficulty.Expert
+ * ```
+ *
+ * Note that, when using values as discriminators, the enum values must be numerical.
+ * Otherwise, an error will be thrown.
+ *
+ * ```ts
+ * enum GameDifficulty { Easy = 'EASY', Normal = 'NORMAL', Hard = 'HARD' }
+ * getEnumCodec(GameDifficulty, { useValuesAsDiscriminators: true }); // Throws an error.
+ * ```
+ *
+ * @example
+ * Using a custom discriminator size.
+ * ```ts
+ * enum Status { Pending, Approved, Rejected }
+ * const codec = getEnumCodec(Status, { size: getU16Codec() });
+ *
+ * codec.encode(Status.Pending);  // 0x0000
+ * codec.encode(Status.Approved); // 0x0100
+ * codec.encode(Status.Rejected); // 0x0200
+ *
+ * codec.decode(new Uint8Array([0x00, 0x00])); // Status.Pending
+ * codec.decode(new Uint8Array([0x01, 0x00])); // Status.Approved
+ * codec.decode(new Uint8Array([0x02, 0x00])); // Status.Rejected
+ * ```
+ *
+ * @remarks
+ * Separate {@link getEnumEncoder} and {@link getEnumDecoder} functions are available.
+ *
+ * ```ts
+ * const bytes = getEnumEncoder(Direction).encode(Direction.Up);
+ * const value = getEnumDecoder(Direction).decode(bytes);
+ * ```
+ *
+ * @see {@link getEnumEncoder}
+ * @see {@link getEnumDecoder}
  */
 export function getEnumCodec<TEnum extends EnumLookupObject>(
     constructor: TEnum,

--- a/packages/codecs-data-structures/src/hidden-prefix.ts
+++ b/packages/codecs-data-structures/src/hidden-prefix.ts
@@ -16,8 +16,35 @@ import {
 import { getTupleDecoder, getTupleEncoder } from './tuple';
 
 /**
- * Prefixes a given encoder with a list of void encoders.
- * All void encoders are hidden from the returned encoder.
+ * Returns an encoder that prefixes encoded values with hidden data.
+ *
+ * This encoder applies a list of void encoders before encoding the main value.
+ * The prefixed data is encoded before the main value without being exposed to the user.
+ *
+ * For more details, see {@link getHiddenPrefixCodec}.
+ *
+ * @typeParam TFrom - The type of the main value being encoded.
+ *
+ * @param encoder - The encoder for the main value.
+ * @param prefixedEncoders - A list of void encoders that produce the hidden prefix.
+ * @returns A `FixedSizeEncoder` or `VariableSizeEncoder` that encodes the value with a hidden prefix.
+ *
+ * @example
+ * Prefixing a value with constants.
+ * ```ts
+ * const encoder = getHiddenPrefixEncoder(getUtf8Encoder(), [
+ *   getConstantCodec(new Uint8Array([1, 2, 3])),
+ *   getConstantCodec(new Uint8Array([4, 5, 6])),
+ * ]);
+ *
+ * encoder.encode('Hello');
+ * // 0x01020304050648656c6c6f
+ * //   |     |     └-- Our encoded value ("Hello").
+ * //   |     └-- Our second hidden prefix.
+ * //   └-- Our first hidden prefix.
+ * ```
+ *
+ * @see {@link getHiddenPrefixCodec}
  */
 export function getHiddenPrefixEncoder<TFrom>(
     encoder: FixedSizeEncoder<TFrom>,
@@ -38,8 +65,32 @@ export function getHiddenPrefixEncoder<TFrom>(
 }
 
 /**
- * Prefixes a given decoder with a list of void decoder.
- * All void decoder are hidden from the returned decoder.
+ * Returns a decoder that skips hidden prefixed data before decoding the main value.
+ *
+ * This decoder applies a list of void decoders before decoding the main value.
+ * The prefixed data is skipped during decoding without being exposed to the user.
+ *
+ * For more details, see {@link getHiddenPrefixCodec}.
+ *
+ * @typeParam TTo - The type of the main value being decoded.
+ *
+ * @param decoder - The decoder for the main value.
+ * @param prefixedDecoders - A list of void decoders that produce the hidden prefix.
+ * @returns A `FixedSizeDecoder` or `VariableSizeDecoder` that decodes values while ignoring the hidden prefix.
+ *
+ * @example
+ * Decoding a value with prefixed constants.
+ * ```ts
+ * const decoder = getHiddenPrefixDecoder(getUtf8Decoder(), [
+ *   getConstantCodec(new Uint8Array([1, 2, 3])),
+ *   getConstantCodec(new Uint8Array([4, 5, 6])),
+ * ]);
+ *
+ * decoder.decode(new Uint8Array([1, 2, 3, 4, 5, 6, 0x48, 0x65, 0x6C, 0x6C, 0x6F]));
+ * // 'Hello'
+ * ```
+ *
+ * @see {@link getHiddenPrefixCodec}
  */
 export function getHiddenPrefixDecoder<TTo>(
     decoder: FixedSizeDecoder<TTo>,
@@ -60,8 +111,58 @@ export function getHiddenPrefixDecoder<TTo>(
 }
 
 /**
- * Prefixes a given codec with a list of void codec.
- * All void codec are hidden from the returned codec.
+ * Returns a codec that encodes and decodes values with a hidden prefix.
+ *
+ * - **Encoding:** Prefixes the value with hidden data before encoding.
+ * - **Decoding:** Skips the hidden prefix before decoding the main value.
+ *
+ * This is useful for any implicit metadata that should be present in
+ * binary formats but omitted from the API.
+ *
+ * @typeParam TFrom - The type of the main value being encoded.
+ * @typeParam TTo - The type of the main value being decoded.
+ *
+ * @param codec - The codec for the main value.
+ * @param prefixedCodecs - A list of void codecs that produce the hidden prefix.
+ * @returns A `FixedSizeCodec` or `VariableSizeCodec` for encoding and decoding values with a hidden prefix.
+ *
+ * @example
+ * Encoding and decoding a value with prefixed constants.
+ * ```ts
+ * const codec = getHiddenPrefixCodec(getUtf8Codec(), [
+ *   getConstantCodec(new Uint8Array([1, 2, 3])),
+ *   getConstantCodec(new Uint8Array([4, 5, 6])),
+ * ]);
+ *
+ * const bytes = codec.encode('Hello');
+ * // 0x01020304050648656c6c6f
+ * //   |     |     └-- Our encoded value ("Hello").
+ * //   |     └-- Our second hidden prefix.
+ * //   └-- Our first hidden prefix.
+ *
+ * codec.decode(bytes);
+ * // 'Hello'
+ * ```
+ *
+ * @remarks
+ * If all you need is padding zeroes before a value, consider using {@link padLeftCodec} instead.
+ *
+ * Separate {@link getHiddenPrefixEncoder} and {@link getHiddenPrefixDecoder} functions are available.
+ *
+ * ```ts
+ * const bytes = getHiddenPrefixEncoder(getUtf8Encoder(), [
+ *   getConstantEncoder(new Uint8Array([1, 2, 3])),
+ *   getConstantEncoder(new Uint8Array([4, 5, 6])),
+ * ]).encode('Hello');
+ *
+ * const value = getHiddenPrefixDecoder(getUtf8Decoder(), [
+ *   getConstantDecoder(new Uint8Array([1, 2, 3])),
+ *   getConstantDecoder(new Uint8Array([4, 5, 6])),
+ * ]).decode(bytes);
+ * ```
+ *
+ * @see {@link getHiddenPrefixEncoder}
+ * @see {@link getHiddenPrefixDecoder}
  */
 export function getHiddenPrefixCodec<TFrom, TTo extends TFrom>(
     codec: FixedSizeCodec<TFrom, TTo>,

--- a/packages/codecs-data-structures/src/hidden-suffix.ts
+++ b/packages/codecs-data-structures/src/hidden-suffix.ts
@@ -16,8 +16,35 @@ import {
 import { getTupleDecoder, getTupleEncoder } from './tuple';
 
 /**
- * Suffixes a given encoder with a list of void encoders.
- * All void encoders are hidden from the returned encoder.
+ * Returns an encoder that appends hidden data after the encoded value.
+ *
+ * This encoder applies a list of void encoders after encoding the main value.
+ * The suffixed data is encoded after the main value without being exposed to the user.
+ *
+ * For more details, see {@link getHiddenSuffixCodec}.
+ *
+ * @typeParam TFrom - The type of the main value being encoded.
+ *
+ * @param encoder - The encoder for the main value.
+ * @param suffixedEncoders - A list of void encoders that produce the hidden suffix.
+ * @returns A `FixedSizeEncoder` or `VariableSizeEncoder` that encodes the value with a hidden suffix.
+ *
+ * @example
+ * Suffixing a value with constants.
+ * ```ts
+ * const encoder = getHiddenSuffixEncoder(getUtf8Encoder(), [
+ *   getConstantCodec(new Uint8Array([1, 2, 3])),
+ *   getConstantCodec(new Uint8Array([4, 5, 6])),
+ * ]);
+ *
+ * encoder.encode('Hello');
+ * // 0x48656c6c6f010203040506
+ * //   |         |     └-- Our second hidden suffix.
+ * //   |         └-- Our first hidden suffix.
+ * //   └-- Our encoded value ("Hello").
+ * ```
+ *
+ * @see {@link getHiddenSuffixCodec}
  */
 export function getHiddenSuffixEncoder<TFrom>(
     encoder: FixedSizeEncoder<TFrom>,
@@ -38,8 +65,32 @@ export function getHiddenSuffixEncoder<TFrom>(
 }
 
 /**
- * Suffixes a given decoder with a list of void decoder.
- * All void decoder are hidden from the returned decoder.
+ * Returns a decoder that skips hidden suffixed data after decoding the main value.
+ *
+ * This decoder applies a list of void decoders after decoding the main value.
+ * The suffixed data is skipped during decoding without being exposed to the user.
+ *
+ * For more details, see {@link getHiddenSuffixCodec}.
+ *
+ * @typeParam TTo - The type of the main value being decoded.
+ *
+ * @param decoder - The decoder for the main value.
+ * @param suffixedDecoders - A list of void decoders that produce the hidden suffix.
+ * @returns A `FixedSizeDecoder` or `VariableSizeDecoder` that decodes values while ignoring the hidden suffix.
+ *
+ * @example
+ * Decoding a value with suffixed constants.
+ * ```ts
+ * const decoder = getHiddenSuffixDecoder(getUtf8Decoder(), [
+ *   getConstantCodec(new Uint8Array([1, 2, 3])),
+ *   getConstantCodec(new Uint8Array([4, 5, 6])),
+ * ]);
+ *
+ * decoder.decode(new Uint8Array([0x48, 0x65, 0x6C, 0x6C, 0x6F, 1, 2, 3, 4, 5, 6]));
+ * // 'Hello'
+ * ```
+ *
+ * @see {@link getHiddenSuffixCodec}
  */
 export function getHiddenSuffixDecoder<TTo>(
     decoder: FixedSizeDecoder<TTo>,
@@ -60,8 +111,58 @@ export function getHiddenSuffixDecoder<TTo>(
 }
 
 /**
- * Suffixes a given codec with a list of void codec.
- * All void codec are hidden from the returned codec.
+ * Returns a codec that encodes and decodes values with a hidden suffix.
+ *
+ * - **Encoding:** Appends hidden data after encoding the main value.
+ * - **Decoding:** Skips the hidden suffix after decoding the main value.
+ *
+ * This is useful for any implicit metadata that should be present in
+ * binary formats but omitted from the API.
+ *
+ * @typeParam TFrom - The type of the main value being encoded.
+ * @typeParam TTo - The type of the main value being decoded.
+ *
+ * @param codec - The codec for the main value.
+ * @param suffixedCodecs - A list of void codecs that produce the hidden suffix.
+ * @returns A `FixedSizeCodec` or `VariableSizeCodec` for encoding and decoding values with a hidden suffix.
+ *
+ * @example
+ * Encoding and decoding a value with suffixed constants.
+ * ```ts
+ * const codec = getHiddenSuffixCodec(getUtf8Codec(), [
+ *   getConstantCodec(new Uint8Array([1, 2, 3])),
+ *   getConstantCodec(new Uint8Array([4, 5, 6])),
+ * ]);
+ *
+ * const bytes = codec.encode('Hello');
+ * // 0x48656c6c6f010203040506
+ * //   |         |     └-- Our second hidden suffix.
+ * //   |         └-- Our first hidden suffix.
+ * //   └-- Our encoded value ("Hello").
+ *
+ * codec.decode(bytes);
+ * // 'Hello'
+ * ```
+ *
+ * @remarks
+ * If all you need is padding zeroes after a value, consider using {@link padRightCodec} instead.
+ *
+ * Separate {@link getHiddenSuffixEncoder} and {@link getHiddenSuffixDecoder} functions are available.
+ *
+ * ```ts
+ * const bytes = getHiddenSuffixEncoder(getUtf8Encoder(), [
+ *   getConstantEncoder(new Uint8Array([1, 2, 3])),
+ *   getConstantEncoder(new Uint8Array([4, 5, 6])),
+ * ]).encode('Hello');
+ *
+ * const value = getHiddenSuffixDecoder(getUtf8Decoder(), [
+ *   getConstantDecoder(new Uint8Array([1, 2, 3])),
+ *   getConstantDecoder(new Uint8Array([4, 5, 6])),
+ * ]).decode(bytes);
+ * ```
+ *
+ * @see {@link getHiddenSuffixEncoder}
+ * @see {@link getHiddenSuffixDecoder}
  */
 export function getHiddenSuffixCodec<TFrom, TTo extends TFrom>(
     codec: FixedSizeCodec<TFrom, TTo>,

--- a/packages/codecs-data-structures/src/index.ts
+++ b/packages/codecs-data-structures/src/index.ts
@@ -1,3 +1,13 @@
+/**
+ * This package contains codecs for various data structures such as arrays, maps, structs, tuples, enums, etc.
+ * It can be used standalone, but it is also exported as part of the Solana JavaScript SDK
+ * [`@solana/web3.js@next`](https://github.com/anza-xyz/solana-web3.js/tree/main/packages/library).
+ *
+ * This package is also part of the [`@solana/codecs` package](https://github.com/anza-xyz/solana-web3.js/tree/main/packages/codecs)
+ * which acts as an entry point for all codec packages as well as for their documentation.
+ *
+ * @packageDocumentation
+ */
 export * from './array';
 export * from './assertions';
 export * from './bit-array';

--- a/packages/codecs-data-structures/src/literal-union.ts
+++ b/packages/codecs-data-structures/src/literal-union.ts
@@ -28,11 +28,19 @@ import {
     SolanaError,
 } from '@solana/errors';
 
-/** Defines the config for literal union codecs. */
+/**
+ * Defines the configuration options for literal union codecs.
+ *
+ * A literal union codec encodes values from a predefined set of literals.
+ * The `size` option determines the numerical encoding used for the discriminant.
+ * By default, literals are stored as a `u8` (1 byte).
+ *
+ * @typeParam TDiscriminator - A number codec, encoder, or decoder used for the discriminant.
+ */
 export type LiteralUnionCodecConfig<TDiscriminator = NumberCodec | NumberDecoder | NumberEncoder> = {
     /**
-     * The number codec to use for the literal union discriminator.
-     * @defaultValue u8 discriminator.
+     * The codec used to encode/decode the discriminator.
+     * @defaultValue `u8` discriminator.
      */
     size?: TDiscriminator;
 };
@@ -41,10 +49,31 @@ type Variant = bigint | boolean | number | string | null | undefined;
 type GetTypeFromVariants<TVariants extends readonly Variant[]> = TVariants[number];
 
 /**
- * Creates a literal union encoder.
+ * Returns an encoder for literal unions.
  *
- * @param variants - The variant encoders of the literal union.
- * @param config - A set of config for the encoder.
+ * This encoder serializes a value from a predefined set of literals
+ * as a numerical index representing its position in the `variants` array.
+ *
+ * For more details, see {@link getLiteralUnionCodec}.
+ *
+ * @typeParam TVariants - A tuple of allowed literal values.
+ *
+ * @param variants - The possible literal values for the union.
+ * @param config - Configuration options for encoding the literal union.
+ * @returns A `FixedSizeEncoder` or `VariableSizeEncoder` for encoding literal unions.
+ *
+ * @example
+ * Encoding a union of string literals.
+ * ```ts
+ * type Size = 'small' | 'medium' | 'large';
+ * const sizeEncoder = getLiteralUnionEncoder(['small', 'medium', 'large']);
+ *
+ * sizeEncoder.encode('small');  // 0x00
+ * sizeEncoder.encode('medium'); // 0x01
+ * sizeEncoder.encode('large');  // 0x02
+ * ```
+ *
+ * @see {@link getLiteralUnionCodec}
  */
 export function getLiteralUnionEncoder<const TVariants extends readonly Variant[]>(
     variants: TVariants,
@@ -75,10 +104,31 @@ export function getLiteralUnionEncoder<const TVariants extends readonly Variant[
 }
 
 /**
- * Creates a literal union decoder.
+ * Returns a decoder for literal unions.
  *
- * @param variants - The variant decoders of the literal union.
- * @param config - A set of config for the decoder.
+ * This decoder deserializes a numerical index into a corresponding
+ * value from a predefined set of literals.
+ *
+ * For more details, see {@link getLiteralUnionCodec}.
+ *
+ * @typeParam TVariants - A tuple of allowed literal values.
+ *
+ * @param variants - The possible literal values for the union.
+ * @param config - Configuration options for decoding the literal union.
+ * @returns A `FixedSizeDecoder` or `VariableSizeDecoder` for decoding literal unions.
+ *
+ * @example
+ * Decoding a union of string literals.
+ * ```ts
+ * type Size = 'small' | 'medium' | 'large';
+ * const sizeDecoder = getLiteralUnionDecoder(['small', 'medium', 'large']);
+ *
+ * sizeDecoder.decode(new Uint8Array([0x00])); // 'small'
+ * sizeDecoder.decode(new Uint8Array([0x01])); // 'medium'
+ * sizeDecoder.decode(new Uint8Array([0x02])); // 'large'
+ * ```
+ *
+ * @see {@link getLiteralUnionCodec}
  */
 export function getLiteralUnionDecoder<const TVariants extends readonly Variant[]>(
     variants: TVariants,
@@ -109,12 +159,77 @@ export function getLiteralUnionDecoder<const TVariants extends readonly Variant[
 }
 
 /**
- * Creates a literal union codec.
+ * Returns a codec for encoding and decoding literal unions.
  *
- * @param variants - The variant codecs of the literal union.
- * @param config - A set of config for the codec.
+ * A literal union codec serializes and deserializes values
+ * from a predefined set of literals, using a numerical index
+ * to represent each value in the `variants` array.
+ *
+ * This allows efficient storage and retrieval of common
+ * predefined values such as enum-like structures in TypeScript.
+ *
+ * @typeParam TVariants - A tuple of allowed literal values.
+ *
+ * @param variants - The possible literal values for the union.
+ * @param config - Configuration options for encoding and decoding the literal union.
+ * @returns A `FixedSizeCodec` or `VariableSizeCodec` for encoding and decoding literal unions.
+ *
+ * @example
+ * Encoding and decoding a union of string literals.
+ * ```ts
+ * type Size = 'small' | 'medium' | 'large';
+ * const sizeCodec = getLiteralUnionCodec(['small', 'medium', 'large']);
+ *
+ * sizeCodec.encode('small');  // 0x00
+ * sizeCodec.encode('medium'); // 0x01
+ * sizeCodec.encode('large');  // 0x02
+ *
+ * sizeCodec.decode(new Uint8Array([0x00])); // 'small'
+ * sizeCodec.decode(new Uint8Array([0x01])); // 'medium'
+ * sizeCodec.decode(new Uint8Array([0x02])); // 'large'
+ * ```
+ *
+ * @example
+ * Encoding and decoding a union of number literals.
+ * ```ts
+ * type Level = 10 | 20 | 30;
+ * const levelCodec = getLiteralUnionCodec([10, 20, 30]);
+ *
+ * levelCodec.encode(10);  // 0x00
+ * levelCodec.encode(20);  // 0x01
+ * levelCodec.encode(30);  // 0x02
+ *
+ * levelCodec.decode(new Uint8Array([0x00])); // 10
+ * levelCodec.decode(new Uint8Array([0x01])); // 20
+ * levelCodec.decode(new Uint8Array([0x02])); // 30
+ * ```
+ *
+ * @example
+ * Using a custom discriminator size with different variant types.
+ * ```ts
+ * type MaybeBoolean = false | true | "either";
+ * const codec = getLiteralUnionCodec([false, true, 'either'], { size: getU16Codec() });
+ *
+ * codec.encode(false);    // 0x0000
+ * codec.encode(true);     // 0x0100
+ * codec.encode('either'); // 0x0200
+ *
+ * codec.decode(new Uint8Array([0x00, 0x00])); // false
+ * codec.decode(new Uint8Array([0x01, 0x00])); // true
+ * codec.decode(new Uint8Array([0x02, 0x00])); // 'either'
+ * ```
+ *
+ * @remarks
+ * Separate {@link getLiteralUnionEncoder} and {@link getLiteralUnionDecoder} functions are available.
+ *
+ * ```ts
+ * const bytes = getLiteralUnionEncoder(['red', 'green', 'blue']).encode('green');
+ * const value = getLiteralUnionDecoder(['red', 'green', 'blue']).decode(bytes);
+ * ```
+ *
+ * @see {@link getLiteralUnionEncoder}
+ * @see {@link getLiteralUnionDecoder}
  */
-
 export function getLiteralUnionCodec<const TVariants extends readonly Variant[]>(
     variants: TVariants,
 ): FixedSizeCodec<GetTypeFromVariants<TVariants>, GetTypeFromVariants<TVariants>, 1>;

--- a/packages/codecs-data-structures/src/map.ts
+++ b/packages/codecs-data-structures/src/map.ts
@@ -17,21 +17,57 @@ import { NumberCodec, NumberDecoder, NumberEncoder } from '@solana/codecs-number
 import { ArrayLikeCodecSize, getArrayDecoder, getArrayEncoder } from './array';
 import { getTupleDecoder, getTupleEncoder } from './tuple';
 
-/** Defines the config for Map codecs. */
+/**
+ * Defines the configuration options for map codecs.
+ *
+ * The `size` option determines how the number of entries in the map is stored.
+ * It can be:
+ * - A {@link NumberCodec} to prefix the map with its size.
+ * - A fixed number of entries.
+ * - `'remainder'`, which infers the number of entries based on the remaining bytes.
+ *   This option is only available for fixed-size keys and values.
+ *
+ * @typeParam TPrefix - A number codec, encoder, or decoder used for the size prefix.
+ */
 export type MapCodecConfig<TPrefix extends NumberCodec | NumberDecoder | NumberEncoder> = {
     /**
-     * The size of the array.
+     * The size of the map.
      * @defaultValue u32 prefix.
      */
     size?: ArrayLikeCodecSize<TPrefix>;
 };
 
 /**
- * Creates a encoder for a map.
+ * Returns an encoder for maps.
  *
- * @param key - The encoder to use for the map's keys.
- * @param value - The encoder to use for the map's values.
- * @param config - A set of config for the encoder.
+ * This encoder serializes maps where the keys and values are encoded
+ * using the provided key and value encoders. The number of entries
+ * is determined by the `size` configuration.
+ *
+ * For more details, see {@link getMapCodec}.
+ *
+ * @typeParam TFromKey - The type of the keys before encoding.
+ * @typeParam TFromValue - The type of the values before encoding.
+ *
+ * @param key - The encoder for the map's keys.
+ * @param value - The encoder for the map's values.
+ * @param config - Configuration options for encoding the map.
+ * @returns A `FixedSizeEncoder` or `VariableSizeEncoder` for encoding maps.
+ *
+ * @example
+ * Encoding a map with a `u32` size prefix.
+ * ```ts
+ * const encoder = getMapEncoder(fixCodecSize(getUtf8Encoder(), 5), getU8Encoder());
+ * const bytes = encoder.encode(new Map([['alice', 42], ['bob', 5]]));
+ * // 0x02000000616c6963652a626f62000005
+ * //   |       |         | |         └── Value (5)
+ * //   |       |         | └── Key ("bob", 5 bytes fixed, null-padded)
+ * //   |       |         └── Value (42)
+ * //   |       └── Key ("alice", 5 bytes fixed)
+ * //   └── 4-byte prefix (2 entries)
+ * ```
+ *
+ * @see {@link getMapCodec}
  */
 export function getMapEncoder<TFromKey, TFromValue>(
     key: Encoder<TFromKey>,
@@ -60,11 +96,33 @@ export function getMapEncoder<TFromKey, TFromValue>(
 }
 
 /**
- * Creates a decoder for a map.
+ * Returns a decoder for maps.
  *
- * @param key - The decoder to use for the map's keys.
- * @param value - The decoder to use for the map's values.
- * @param config - A set of config for the decoder.
+ * This decoder deserializes maps where the keys and values are decoded
+ * using the provided key and value decoders. The number of entries
+ * is determined by the `size` configuration.
+ *
+ * For more details, see {@link getMapCodec}.
+ *
+ * @typeParam TToKey - The type of the keys after decoding.
+ * @typeParam TToValue - The type of the values after decoding.
+ *
+ * @param key - The decoder for the map's keys.
+ * @param value - The decoder for the map's values.
+ * @param config - Configuration options for decoding the map.
+ * @returns A `FixedSizeDecoder` or `VariableSizeDecoder` for decoding maps.
+ *
+ * @example
+ * Decoding a map with a `u32` size prefix.
+ * ```ts
+ * const decoder = getMapDecoder(fixCodecSize(getUtf8Decoder(), 5), getU8Decoder());
+ * const map = decoder.decode(new Uint8Array([
+ *   0x02,0x00,0x00,0x00,0x61,0x6c,0x69,0x63,0x65,0x2a,0x62,0x6f,0x62,0x00,0x00,0x05
+ * ]));
+ * // new Map([['alice', 42], ['bob', 5]])
+ * ```
+ *
+ * @see {@link getMapCodec}
  */
 export function getMapDecoder<TToKey, TToValue>(
     key: Decoder<TToKey>,
@@ -93,11 +151,95 @@ export function getMapDecoder<TToKey, TToValue>(
 }
 
 /**
- * Creates a codec for a map.
+ * Returns a codec for encoding and decoding maps.
  *
- * @param key - The codec to use for the map's keys.
- * @param value - The codec to use for the map's values.
- * @param config - A set of config for the codec.
+ * This codec serializes maps where the key/value pairs are encoded
+ * and decoded one after another using the provided key and value codecs.
+ * The number of entries is determined by the `size` configuration and
+ * defaults to a `u32` size prefix.
+ *
+ * @typeParam TFromKey - The type of the keys before encoding.
+ * @typeParam TFromValue - The type of the values before encoding.
+ * @typeParam TToKey - The type of the keys after decoding.
+ * @typeParam TToValue - The type of the values after decoding.
+ *
+ * @param key - The codec for the map's keys.
+ * @param value - The codec for the map's values.
+ * @param config - Configuration options for encoding and decoding the map.
+ * @returns A `FixedSizeCodec` or `VariableSizeCodec` for encoding and decoding maps.
+ *
+ * @example
+ * Encoding and decoding a map with a `u32` size prefix (default).
+ * ```ts
+ * const codec = getMapCodec(fixCodecSize(getUtf8Codec(), 5), getU8Codec());
+ * const bytes = codec.encode(new Map([['alice', 42], ['bob', 5]]));
+ * // 0x02000000616c6963652a626f62000005
+ * //   |       |         | |         └── Value (5)
+ * //   |       |         | └── Key ("bob", 5 bytes fixed, null-padded)
+ * //   |       |         └── Value (42)
+ * //   |       └── Key ("alice", 5 bytes fixed)
+ * //   └── 4-byte prefix (2 entries)
+ *
+ * const map = codec.decode(bytes);
+ * // new Map([['alice', 42], ['bob', 5]])
+ * ```
+ *
+ * @example
+ * Encoding and decoding a map with a `u16` size prefix.
+ * ```ts
+ * const codec = getMapCodec(fixCodecSize(getUtf8Codec(), 5), getU8Codec(), { size: getU16Codec() });
+ * const bytes = codec.encode(new Map([['alice', 42], ['bob', 5]]));
+ * // 0x0200616c6963652a626f62000005
+ * //   |   |         | |         └── Value (5)
+ * //   |   |         | └── Key ("bob", 5 bytes fixed, null-padded)
+ * //   |   |         └── Value (42)
+ * //   |   └── Key ("alice", 5 bytes fixed)
+ * //   └── 2-byte prefix (2 entries)
+ *
+ * const map = codec.decode(bytes);
+ * // new Map([['alice', 42], ['bob', 5]])
+ * ```
+ *
+ * @example
+ * Encoding and decoding a fixed-size map.
+ * ```ts
+ * const codec = getMapCodec(fixCodecSize(getUtf8Codec(), 5), getU8Codec(), { size: 2 });
+ * const bytes = codec.encode(new Map([['alice', 42], ['bob', 5]]));
+ * // 0x616c6963652a626f62000005
+ * //   |         | |         └── Value (5)
+ * //   |         | └── Key ("bob", 5 bytes fixed, null-padded)
+ * //   |         └── Value (42)
+ * //   └── Key ("alice", 5 bytes fixed)
+ *
+ * const map = codec.decode(bytes);
+ * // new Map([['alice', 42], ['bob', 5]])
+ * ```
+ *
+ * @example
+ * Encoding and decoding a map with remainder size.
+ * ```ts
+ * const codec = getMapCodec(fixCodecSize(getUtf8Codec(), 5), getU8Codec(), { size: 'remainder' });
+ * const bytes = codec.encode(new Map([['alice', 42], ['bob', 5]]));
+ * // 0x616c6963652a626f62000005
+ * //   |         | |         └── Value (5)
+ * //   |         | └── Key ("bob", 5 bytes fixed, null-padded)
+ * //   |         └── Value (42)
+ * //   └── Key ("alice", 5 bytes fixed)
+ * // No size prefix, the size is inferred from the remaining bytes.
+ *
+ * const map = codec.decode(bytes);
+ * // new Map([['alice', 42], ['bob', 5]])
+ * ```
+ *
+ * @remarks
+ * Separate {@link getMapEncoder} and {@link getMapDecoder} functions are available.
+ * ```ts
+ * const bytes = getMapEncoder(fixCodecSize(getUtf8Encoder(), 5), getU8Encoder()).encode(new Map([['alice', 42]]));
+ * const map = getMapDecoder(fixCodecSize(getUtf8Decoder(), 5), getU8Decoder()).decode(bytes);
+ * ```
+ *
+ * @see {@link getMapEncoder}
+ * @see {@link getMapDecoder}
  */
 export function getMapCodec<
     TFromKey,

--- a/packages/codecs-data-structures/src/set.ts
+++ b/packages/codecs-data-structures/src/set.ts
@@ -16,20 +16,51 @@ import { NumberCodec, NumberDecoder, NumberEncoder } from '@solana/codecs-number
 
 import { ArrayLikeCodecSize, getArrayDecoder, getArrayEncoder } from './array';
 
-/** Defines the config for set codecs. */
+/**
+ * Defines the configuration options for set codecs.
+ *
+ * This configuration allows specifying how the size of the set is encoded.
+ * The `size` option can be:
+ *
+ * - A {@link NumberCodec}, {@link NumberEncoder}, or {@link NumberDecoder} to store the size as a prefix.
+ * - A fixed number of items, enforcing a strict length.
+ * - The string `'remainder'` to infer the set size from the remaining bytes (only for fixed-size items).
+ *
+ * @typeParam TPrefix - The type used for encoding the size of the set.
+ */
 export type SetCodecConfig<TPrefix extends NumberCodec | NumberDecoder | NumberEncoder> = {
     /**
-     * The size of the set.
-     * @defaultValue u32 prefix.
+     * The size encoding strategy for the set.
+     * @defaultValue Uses a `u32` prefix.
      */
     size?: ArrayLikeCodecSize<TPrefix>;
 };
 
 /**
- * Encodes an set of items.
+ * Returns an encoder for sets of items.
  *
- * @param item - The encoder to use for the set's items.
- * @param config - A set of config for the encoder.
+ * This encoder serializes `Set<T>` values by encoding each item using the provided item encoder.
+ * The number of items is stored as a prefix using a `u32` codec by default.
+ *
+ * For more details, see {@link getSetCodec}.
+ *
+ * @typeParam TFrom - The type of the items in the set before encoding.
+ *
+ * @param item - The encoder to use for each set item.
+ * @param config - Optional configuration specifying the size strategy.
+ * @returns An `Encoder<Set<TFrom>>` for encoding sets of items.
+ *
+ * @example
+ * Encoding a set of `u8` numbers.
+ * ```ts
+ * const encoder = getSetEncoder(getU8Encoder());
+ * const bytes = encoder.encode(new Set([1, 2, 3]));
+ * // 0x03000000010203
+ * //   |       └-- 3 items of 1 byte each.
+ * //   └-- 4-byte prefix indicating 3 items.
+ * ```
+ *
+ * @see {@link getSetCodec}
  */
 export function getSetEncoder<TFrom>(
     item: Encoder<TFrom>,
@@ -51,10 +82,28 @@ export function getSetEncoder<TFrom>(
 }
 
 /**
- * Decodes an set of items.
+ * Returns a decoder for sets of items.
  *
- * @param item - The encoder to use for the set's items.
- * @param config - A set of config for the encoder.
+ * This decoder deserializes a `Set<T>` from a byte array by decoding each item using the provided item decoder.
+ * The number of items is determined by a `u32` size prefix by default.
+ *
+ * For more details, see {@link getSetCodec}.
+ *
+ * @typeParam TTo - The type of the items in the set after decoding.
+ *
+ * @param item - The decoder to use for each set item.
+ * @param config - Optional configuration specifying the size strategy.
+ * @returns A `Decoder<Set<TTo>>` for decoding sets of items.
+ *
+ * @example
+ * Decoding a set of `u8` numbers.
+ * ```ts
+ * const decoder = getSetDecoder(getU8Decoder());
+ * const value = decoder.decode(new Uint8Array([0x03, 0x00, 0x00, 0x00, 0x01, 0x02, 0x03]));
+ * // new Set([1, 2, 3])
+ * ```
+ *
+ * @see {@link getSetCodec}
  */
 export function getSetDecoder<TTo>(
     item: Decoder<TTo>,
@@ -73,10 +122,69 @@ export function getSetDecoder<TTo>(item: Decoder<TTo>, config: SetCodecConfig<Nu
 }
 
 /**
- * Creates a codec for an set of items.
+ * Returns a codec for encoding and decoding sets of items.
  *
- * @param item - The codec to use for the set's items.
- * @param config - A set of config for the codec.
+ * This codec serializes `Set<T>` values by encoding each item using the provided item codec.
+ * The number of items is stored as a prefix using a `u32` codec by default.
+ *
+ * @typeParam TFrom - The type of the items in the set before encoding.
+ * @typeParam TTo - The type of the items in the set after decoding.
+ *
+ * @param item - The codec to use for each set item.
+ * @param config - Optional configuration specifying the size strategy.
+ * @returns A `Codec<Set<TFrom>, Set<TTo>>` for encoding and decoding sets.
+ *
+ * @example
+ * Encoding and decoding a set of `u8` numbers.
+ * ```ts
+ * const codec = getSetCodec(getU8Codec());
+ * const bytes = codec.encode(new Set([1, 2, 3]));
+ * // 0x03000000010203
+ * //   |       └-- 3 items of 1 byte each.
+ * //   └-- 4-byte prefix indicating 3 items.
+ *
+ * const value = codec.decode(bytes);
+ * // new Set([1, 2, 3])
+ * ```
+ *
+ * @example
+ * Using a `u16` prefix for size.
+ * ```ts
+ * const codec = getSetCodec(getU8Codec(), { size: getU16Codec() });
+ * const bytes = codec.encode(new Set([1, 2, 3]));
+ * // 0x0300010203
+ * //   |   └-- 3 items of 1 byte each.
+ * //   └-- 2-byte prefix indicating 3 items.
+ * ```
+ *
+ * @example
+ * Using a fixed-size set.
+ * ```ts
+ * const codec = getSetCodec(getU8Codec(), { size: 3 });
+ * const bytes = codec.encode(new Set([1, 2, 3]));
+ * // 0x010203
+ * //   └-- Exactly 3 items of 1 byte each.
+ * ```
+ *
+ * @example
+ * Using remainder to infer set size.
+ * ```ts
+ * const codec = getSetCodec(getU8Codec(), { size: 'remainder' });
+ * const bytes = codec.encode(new Set([1, 2, 3]));
+ * // 0x010203
+ * //   └-- 3 items of 1 byte each. The size is inferred from the remaining bytes.
+ * ```
+ *
+ * @remarks
+ * Separate {@link getSetEncoder} and {@link getSetDecoder} functions are available.
+ *
+ * ```ts
+ * const bytes = getSetEncoder(getU8Encoder()).encode(new Set([1, 2, 3]));
+ * const value = getSetDecoder(getU8Decoder()).decode(bytes);
+ * ```
+ *
+ * @see {@link getSetEncoder}
+ * @see {@link getSetDecoder}
  */
 export function getSetCodec<TFrom, TTo extends TFrom = TFrom>(
     item: Codec<TFrom, TTo>,

--- a/packages/codecs-data-structures/src/struct.ts
+++ b/packages/codecs-data-structures/src/struct.ts
@@ -18,21 +18,69 @@ import {
 
 import { DrainOuterGeneric, getFixedSize, getMaxSize, sumCodecSizes } from './utils';
 
+/**
+ * Represents a collection of named fields used in struct codecs.
+ *
+ * Each field is defined as a tuple containing:
+ * - A string key representing the field name.
+ * - A codec used to encode and decode the field's value.
+ *
+ * @typeParam T - The codec type used for each field.
+ */
 type Fields<T> = readonly (readonly [string, T])[];
+
 type ArrayIndices<T extends readonly unknown[]> = Exclude<Partial<T>['length'], T['length']> & number;
 
+/**
+ * Infers the TypeScript type for an object that can be encoded using a struct codec.
+ *
+ * This type maps the provided field encoders to their corresponding values.
+ *
+ * @typeParam TFields - The fields of the struct, each paired with an encoder.
+ */
 type GetEncoderTypeFromFields<TFields extends Fields<Encoder<any>>> = DrainOuterGeneric<{
     [I in ArrayIndices<TFields> as TFields[I][0]]: TFields[I][1] extends Encoder<infer TFrom> ? TFrom : never;
 }>;
 
+/**
+ * Infers the TypeScript type for an object that can be decoded using a struct codec.
+ *
+ * This type maps the provided field decoders to their corresponding values.
+ *
+ * @typeParam TFields - The fields of the struct, each paired with a decoder.
+ */
 type GetDecoderTypeFromFields<TFields extends Fields<Decoder<any>>> = DrainOuterGeneric<{
     [I in ArrayIndices<TFields> as TFields[I][0]]: TFields[I][1] extends Decoder<infer TTo> ? TTo : never;
 }>;
 
 /**
- * Creates a encoder for a custom object.
+ * Returns an encoder for custom objects.
+ *
+ * This encoder serializes an object by encoding its fields sequentially,
+ * using the provided field encoders.
+ *
+ * For more details, see {@link getStructCodec}.
+ *
+ * @typeParam TFields - The fields of the struct, each paired with an encoder.
  *
  * @param fields - The name and encoder of each field.
+ * @returns A `FixedSizeEncoder` or `VariableSizeEncoder` for encoding custom objects.
+ *
+ * @example
+ * Encoding a custom struct.
+ * ```ts
+ * const encoder = getStructEncoder([
+ *   ['name', fixCodecSize(getUtf8Encoder(), 5)],
+ *   ['age', getU8Encoder()]
+ * ]);
+ *
+ * const bytes = encoder.encode({ name: 'Alice', age: 42 });
+ * // 0x416c6963652a
+ * //   |         └── Age (42)
+ * //   └── Name ("Alice")
+ * ```
+ *
+ * @see {@link getStructCodec}
  */
 export function getStructEncoder<const TFields extends Fields<FixedSizeEncoder<any>>>(
     fields: TFields,
@@ -68,9 +116,33 @@ export function getStructEncoder<const TFields extends Fields<Encoder<any>>>(
 }
 
 /**
- * Creates a decoder for a custom object.
+ * Returns a decoder for custom objects.
+ *
+ * This decoder deserializes an object by decoding its fields sequentially,
+ * using the provided field decoders.
+ *
+ * For more details, see {@link getStructCodec}.
+ *
+ * @typeParam TFields - The fields of the struct, each paired with a decoder.
  *
  * @param fields - The name and decoder of each field.
+ * @returns A `FixedSizeDecoder` or `VariableSizeDecoder` for decoding custom objects.
+ *
+ * @example
+ * Decoding a custom struct.
+ * ```ts
+ * const decoder = getStructDecoder([
+ *   ['name', fixCodecSize(getUtf8Decoder(), 5)],
+ *   ['age', getU8Decoder()]
+ * ]);
+ *
+ * const struct = decoder.decode(new Uint8Array([
+ *   0x41,0x6c,0x69,0x63,0x65,0x2a
+ * ]));
+ * // { name: 'Alice', age: 42 }
+ * ```
+ *
+ * @see {@link getStructCodec}
  */
 export function getStructDecoder<const TFields extends Fields<FixedSizeDecoder<any>>>(
     fields: TFields,
@@ -101,9 +173,49 @@ export function getStructDecoder<const TFields extends Fields<Decoder<any>>>(
 }
 
 /**
- * Creates a codec for a custom object.
+ * Returns a codec for encoding and decoding custom objects.
+ *
+ * This codec serializes objects by encoding and decoding each field sequentially.
+ *
+ * @typeParam TFields - The fields of the struct, each paired with a codec.
  *
  * @param fields - The name and codec of each field.
+ * @returns A `FixedSizeCodec` or `VariableSizeCodec` for encoding and decoding custom objects.
+ *
+ * @example
+ * Encoding and decoding a custom struct.
+ * ```ts
+ * const codec = getStructCodec([
+ *   ['name', fixCodecSize(getUtf8Codec(), 5)],
+ *   ['age', getU8Codec()]
+ * ]);
+ *
+ * const bytes = codec.encode({ name: 'Alice', age: 42 });
+ * // 0x416c6963652a
+ * //   |         └── Age (42)
+ * //   └── Name ("Alice")
+ *
+ * const struct = codec.decode(bytes);
+ * // { name: 'Alice', age: 42 }
+ * ```
+ *
+ * @remarks
+ * Separate {@link getStructEncoder} and {@link getStructDecoder} functions are available.
+ *
+ * ```ts
+ * const bytes = getStructEncoder([
+ *   ['name', fixCodecSize(getUtf8Encoder(), 5)],
+ *   ['age', getU8Encoder()]
+ * ]).encode({ name: 'Alice', age: 42 });
+ *
+ * const struct = getStructDecoder([
+ *   ['name', fixCodecSize(getUtf8Decoder(), 5)],
+ *   ['age', getU8Decoder()]
+ * ]).decode(bytes);
+ * ```
+ *
+ * @see {@link getStructEncoder}
+ * @see {@link getStructDecoder}
  */
 export function getStructCodec<const TFields extends Fields<FixedSizeCodec<any>>>(
     fields: TFields,

--- a/packages/codecs-data-structures/src/tuple.ts
+++ b/packages/codecs-data-structures/src/tuple.ts
@@ -19,18 +19,53 @@ import {
 import { assertValidNumberOfItemsForCodec } from './assertions';
 import { DrainOuterGeneric, getFixedSize, getMaxSize, sumCodecSizes } from './utils';
 
+/**
+ * Infers the TypeScript type for a tuple that can be encoded using a tuple codec.
+ *
+ * This type maps each provided item encoder to its corresponding value type.
+ *
+ * @typeParam TItems - An array of encoders, each corresponding to a tuple element.
+ */
 type GetEncoderTypeFromItems<TItems extends readonly Encoder<any>[]> = DrainOuterGeneric<{
     [I in keyof TItems]: TItems[I] extends Encoder<infer TFrom> ? TFrom : never;
 }>;
 
+/**
+ * Infers the TypeScript type for a tuple that can be decoded using a tuple codec.
+ *
+ * This type maps each provided item decoder to its corresponding value type.
+ *
+ * @typeParam TItems - An array of decoders, each corresponding to a tuple element.
+ */
 type GetDecoderTypeFromItems<TItems extends readonly Decoder<any>[]> = DrainOuterGeneric<{
     [I in keyof TItems]: TItems[I] extends Decoder<infer TTo> ? TTo : never;
 }>;
 
 /**
- * Creates a encoder for a tuple-like array.
+ * Returns an encoder for tuples.
  *
- * @param items - The encoders to use for each item in the tuple.
+ * This encoder serializes a fixed-size array (tuple) by encoding its items
+ * sequentially using the provided item encoders.
+ *
+ * For more details, see {@link getTupleCodec}.
+ *
+ * @typeParam TItems - An array of encoders, each corresponding to a tuple element.
+ *
+ * @param items - The encoders for each item in the tuple.
+ * @returns A `FixedSizeEncoder` or `VariableSizeEncoder` for encoding tuples.
+ *
+ * @example
+ * Encoding a tuple with 2 items.
+ * ```ts
+ * const encoder = getTupleEncoder([fixCodecSize(getUtf8Encoder(), 5), getU8Encoder()]);
+ *
+ * const bytes = encoder.encode(['Alice', 42]);
+ * // 0x416c6963652a
+ * //   |         └── Second item (42)
+ * //   └── First item ("Alice")
+ * ```
+ *
+ * @see {@link getTupleCodec}
  */
 export function getTupleEncoder<const TItems extends readonly FixedSizeEncoder<any>[]>(
     items: TItems,
@@ -64,11 +99,31 @@ export function getTupleEncoder<const TItems extends readonly Encoder<any>[]>(
 }
 
 /**
- * Creates a decoder for a tuple-like array.
+ * Returns a decoder for tuples.
  *
- * @param items - The decoders to use for each item in the tuple.
+ * This decoder deserializes a fixed-size array (tuple) by decoding its items
+ * sequentially using the provided item decoders.
+ *
+ * For more details, see {@link getTupleCodec}.
+ *
+ * @typeParam TItems - An array of decoders, each corresponding to a tuple element.
+ *
+ * @param items - The decoders for each item in the tuple.
+ * @returns A `FixedSizeDecoder` or `VariableSizeDecoder` for decoding tuples.
+ *
+ * @example
+ * Decoding a tuple with 2 items.
+ * ```ts
+ * const decoder = getTupleDecoder([fixCodecSize(getUtf8Decoder(), 5), getU8Decoder()]);
+ *
+ * const tuple = decoder.decode(new Uint8Array([
+ *   0x41,0x6c,0x69,0x63,0x65,0x2a
+ * ]));
+ * // ['Alice', 42]
+ * ```
+ *
+ * @see {@link getTupleCodec}
  */
-
 export function getTupleDecoder<const TItems extends readonly FixedSizeDecoder<any>[]>(
     items: TItems,
 ): FixedSizeDecoder<GetDecoderTypeFromItems<TItems>>;
@@ -97,9 +152,45 @@ export function getTupleDecoder<const TItems extends readonly Decoder<any>[]>(
 }
 
 /**
- * Creates a codec for a tuple-like array.
+ * Returns a codec for encoding and decoding tuples.
  *
- * @param items - The codecs to use for each item in the tuple.
+ * This codec serializes tuples by encoding and decoding each item sequentially.
+ *
+ * Unlike the {@link getArrayCodec} codec, each item in the tuple has its own codec
+ * and, therefore, can be of a different type.
+ *
+ * @typeParam TItems - An array of codecs, each corresponding to a tuple element.
+ *
+ * @param items - The codecs for each item in the tuple.
+ * @returns A `FixedSizeCodec` or `VariableSizeCodec` for encoding and decoding tuples.
+ *
+ * @example
+ * Encoding and decoding a tuple with 2 items.
+ * ```ts
+ * const codec = getTupleCodec([fixCodecSize(getUtf8Codec(), 5), getU8Codec()]);
+ *
+ * const bytes = codec.encode(['Alice', 42]);
+ * // 0x416c6963652a
+ * //   |         └── Second item (42)
+ * //   └── First item ("Alice")
+ *
+ * const tuple = codec.decode(bytes);
+ * // ['Alice', 42]
+ * ```
+ *
+ * @remarks
+ * Separate {@link getTupleEncoder} and {@link getTupleDecoder} functions are available.
+ *
+ * ```ts
+ * const bytes = getTupleEncoder([fixCodecSize(getUtf8Encoder(), 5), getU8Encoder()])
+ *   .encode(['Alice', 42]);
+ *
+ * const tuple = getTupleDecoder([fixCodecSize(getUtf8Decoder(), 5), getU8Decoder()])
+ *   .decode(bytes);
+ * ```
+ *
+ * @see {@link getTupleEncoder}
+ * @see {@link getTupleDecoder}
  */
 export function getTupleCodec<const TItems extends readonly FixedSizeCodec<any>[]>(
     items: TItems,

--- a/packages/codecs-data-structures/src/union.ts
+++ b/packages/codecs-data-structures/src/union.ts
@@ -15,19 +15,63 @@ import { SOLANA_ERROR__CODECS__UNION_VARIANT_OUT_OF_RANGE, SolanaError } from '@
 
 import { DrainOuterGeneric, getMaxSize, maxCodecSizes } from './utils';
 
+/**
+ * Infers the TypeScript type for values that can be encoded using a union codec.
+ *
+ * This type maps the provided variant encoders to their corresponding value types.
+ *
+ * @typeParam TVariants - An array of encoders, each corresponding to a union variant.
+ */
 type GetEncoderTypeFromVariants<TVariants extends readonly Encoder<any>[]> = DrainOuterGeneric<{
     [I in keyof TVariants]: TVariants[I] extends Encoder<infer TFrom> ? TFrom : never;
 }>[number];
 
+/**
+ * Infers the TypeScript type for values that can be decoded using a union codec.
+ *
+ * This type maps the provided variant decoders to their corresponding value types.
+ *
+ * @typeParam TVariants - An array of decoders, each corresponding to a union variant.
+ */
 type GetDecoderTypeFromVariants<TVariants extends readonly Decoder<any>[]> = DrainOuterGeneric<{
     [I in keyof TVariants]: TVariants[I] extends Decoder<infer TFrom> ? TFrom : never;
 }>[number];
 
 /**
- * Creates a union encoder from the provided array of encoder.
+ * Returns an encoder for union types.
  *
- * @param variants - The variant encoders of the union.
- * @param getIndexFromValue - A function that returns the index of the variant from the provided value.
+ * This encoder serializes values by selecting the correct variant encoder
+ * based on the `getIndexFromValue` function.
+ *
+ * Unlike other codecs, this encoder does not store the variant index.
+ * It is the user's responsibility to manage discriminators separately.
+ *
+ * For more details, see {@link getUnionCodec}.
+ *
+ * @typeParam TVariants - An array of encoders, each corresponding to a union variant.
+ *
+ * @param variants - The encoders for each variant of the union.
+ * @param getIndexFromValue - A function that determines the variant index from the provided value.
+ * @returns An `Encoder` for encoding union values.
+ *
+ * @example
+ * Encoding a union of numbers and booleans.
+ * ```ts
+ * const encoder = getUnionEncoder(
+ *   [getU16Encoder(), getBooleanEncoder()],
+ *   value => (typeof value === 'number' ? 0 : 1)
+ * );
+ *
+ * encoder.encode(42);
+ * // 0x2a00
+ * //   └── Encoded number (42) as `u16`
+ *
+ * encoder.encode(true);
+ * // 0x01
+ * //   └── Encoded boolean (`true`) as `u8`
+ * ```
+ *
+ * @see {@link getUnionCodec}
  */
 export function getUnionEncoder<const TVariants extends readonly Encoder<any>[]>(
     variants: TVariants,
@@ -58,10 +102,36 @@ export function getUnionEncoder<const TVariants extends readonly Encoder<any>[]>
 }
 
 /**
- * Creates a union decoder from the provided array of decoder.
+ * Returns a decoder for union types.
  *
- * @param variants - The variant decoders of the union.
- * @param getIndexFromBytes - A function that returns the index of the variant from the byte array.
+ * This decoder deserializes values by selecting the correct variant decoder
+ * based on the `getIndexFromBytes` function.
+ *
+ * Unlike other codecs, this decoder does not assume a stored discriminator.
+ * It is the user's responsibility to manage discriminators separately.
+ *
+ * For more details, see {@link getUnionCodec}.
+ *
+ * @typeParam TVariants - An array of decoders, each corresponding to a union variant.
+ *
+ * @param variants - The decoders for each variant of the union.
+ * @param getIndexFromBytes - A function that determines the variant index from the byte array.
+ * @returns A `Decoder` for decoding union values.
+ *
+ * @example
+ * Decoding a union of numbers and booleans.
+ * ```ts
+ * const decoder = getUnionDecoder(
+ *   [getU16Decoder(), getBooleanDecoder()],
+ *   (bytes, offset) => (bytes.length - offset > 1 ? 0 : 1)
+ * );
+ *
+ * decoder.decode(new Uint8Array([0x2a, 0x00])); // 42
+ * decoder.decode(new Uint8Array([0x01]));       // true
+ * // Type is inferred as `number | boolean`
+ * ```
+ *
+ * @see {@link getUnionCodec}
  */
 export function getUnionDecoder<const TVariants extends readonly Decoder<any>[]>(
     variants: TVariants,
@@ -84,11 +154,51 @@ export function getUnionDecoder<const TVariants extends readonly Decoder<any>[]>
 }
 
 /**
- * Creates a union codec from the provided array of codec.
+ * Returns a codec for encoding and decoding union types.
  *
- * @param variants - The variant codecs of the union.
- * @param getIndexFromValue - A function that returns the index of the variant from the provided value.
- * @param getIndexFromBytes - A function that returns the index of the variant from the byte array.
+ * This codec serializes and deserializes union values by selecting the correct variant
+ * based on the provided index functions.
+ *
+ * Unlike the {@link getDiscriminatedUnionCodec}, this codec does not assume a stored
+ * discriminator and must be used with an explicit mechanism for managing discriminators.
+ *
+ * @typeParam TVariants - An array of codecs, each corresponding to a union variant.
+ *
+ * @param variants - The codecs for each variant of the union.
+ * @param getIndexFromValue - A function that determines the variant index from the provided value.
+ * @param getIndexFromBytes - A function that determines the variant index from the byte array.
+ * @returns A `Codec` for encoding and decoding union values.
+ *
+ * @example
+ * Encoding and decoding a union of numbers and booleans.
+ * ```ts
+ * const codec = getUnionCodec(
+ *   [getU16Codec(), getBooleanCodec()],
+ *   value => (typeof value === 'number' ? 0 : 1),
+ *   (bytes, offset) => (bytes.length - offset > 1 ? 0 : 1)
+ * );
+ *
+ * const bytes1 = codec.encode(42); // 0x2a00
+ * const value1: number | boolean = codec.decode(bytes1); // 42
+ *
+ * const bytes2 = codec.encode(true); // 0x01
+ * const value2: number | boolean = codec.decode(bytes2); // true
+ * ```
+ *
+ * @remarks
+ * If you need a codec that includes a stored discriminator,
+ * consider using {@link getDiscriminatedUnionCodec}.
+ *
+ * Separate {@link getUnionEncoder} and {@link getUnionDecoder} functions are also available.
+ *
+ * ```ts
+ * const bytes = getUnionEncoder(variantEncoders, getIndexFromValue).encode(42);
+ * const value = getUnionDecoder(variantDecoders, getIndexFromBytes).decode(bytes);
+ * ```
+ *
+ * @see {@link getUnionEncoder}
+ * @see {@link getUnionDecoder}
+ * @see {@link getDiscriminatedUnionCodec}
  */
 export function getUnionCodec<const TVariants extends readonly Codec<any>[]>(
     variants: TVariants,

--- a/packages/codecs-data-structures/src/unit.ts
+++ b/packages/codecs-data-structures/src/unit.ts
@@ -9,7 +9,23 @@ import {
 } from '@solana/codecs-core';
 
 /**
- * Creates a void encoder.
+ * Returns an encoder for `void` values.
+ *
+ * This encoder writes nothing to the byte array and has a fixed size of 0 bytes.
+ * It is useful when working with structures that require a no-op encoder,
+ * such as empty variants in {@link getDiscriminatedUnionEncoder}.
+ *
+ * For more details, see {@link getUnitCodec}.
+ *
+ * @returns A `FixedSizeEncoder<void, 0>`, representing an empty encoder.
+ *
+ * @example
+ * Encoding a `void` value.
+ * ```ts
+ * getUnitEncoder().encode(undefined); // Produces an empty byte array.
+ * ```
+ *
+ * @see {@link getUnitCodec}
  */
 export function getUnitEncoder(): FixedSizeEncoder<void, 0> {
     return createEncoder({
@@ -19,7 +35,23 @@ export function getUnitEncoder(): FixedSizeEncoder<void, 0> {
 }
 
 /**
- * Creates a void decoder.
+ * Returns a decoder for `void` values.
+ *
+ * This decoder always returns `undefined` and has a fixed size of 0 bytes.
+ * It is useful when working with structures that require a no-op decoder,
+ * such as empty variants in {@link getDiscriminatedUnionDecoder}.
+ *
+ * For more details, see {@link getUnitCodec}.
+ *
+ * @returns A `FixedSizeDecoder<void, 0>`, representing an empty decoder.
+ *
+ * @example
+ * Decoding a `void` value.
+ * ```ts
+ * getUnitDecoder().decode(anyBytes); // Returns `undefined`.
+ * ```
+ *
+ * @see {@link getUnitCodec}
  */
 export function getUnitDecoder(): FixedSizeDecoder<void, 0> {
     return createDecoder({
@@ -29,7 +61,50 @@ export function getUnitDecoder(): FixedSizeDecoder<void, 0> {
 }
 
 /**
- * Creates a void codec.
+ * Returns a codec for `void` values.
+ *
+ * This codec does nothing when encoding or decoding and has a fixed size of 0 bytes.
+ * Namely, it always returns `undefined` when decoding and produces an empty byte array when encoding.
+ *
+ * This can be useful when working with structures that require a no-op codec,
+ * such as empty variants in {@link getDiscriminatedUnionCodec}.
+ *
+ * @returns A `FixedSizeCodec<void, void, 0>`, representing an empty codec.
+ *
+ * @example
+ * Encoding and decoding a `void` value.
+ * ```ts
+ * const codec = getUnitCodec();
+ *
+ * codec.encode(undefined); // Produces an empty byte array.
+ * codec.decode(new Uint8Array([])); // Returns `undefined`.
+ * ```
+ *
+ * @example
+ * Using unit codecs as empty variants in a discriminated union.
+ * ```ts
+ * type Message =
+ *   | { __kind: 'Enter' }
+ *   | { __kind: 'Leave' }
+ *   | { __kind: 'Move'; x: number; y: number };
+ *
+ * const messageCodec = getDiscriminatedUnionCodec([
+ *   ['Enter', getUnitCodec()], // <- No-op codec for empty data
+ *   ['Leave', getUnitCodec()], // <- No-op codec for empty data
+ *   ['Move', getStructCodec([...])]
+ * ]);
+ * ```
+ *
+ * @remarks
+ * Separate {@link getUnitEncoder} and {@link getUnitDecoder} functions are available.
+ *
+ * ```ts
+ * const bytes = getUnitEncoder().encode();
+ * const value = getUnitDecoder().decode(bytes);
+ * ```
+ *
+ * @see {@link getUnitEncoder}
+ * @see {@link getUnitDecoder}
  */
 export function getUnitCodec(): FixedSizeCodec<void, void, 0> {
     return combineCodec(getUnitEncoder(), getUnitDecoder());

--- a/packages/codecs-data-structures/typedoc.json
+++ b/packages/codecs-data-structures/typedoc.json
@@ -1,5 +1,6 @@
 {
     "$schema": "https://typedoc.org/schema.json",
     "extends": ["../typedoc.base.json"],
-    "entryPoints": ["src/index.ts"]
+    "entryPoints": ["src/index.ts"],
+    "readme": "none"
 }

--- a/packages/codecs-numbers/src/assertions.ts
+++ b/packages/codecs-numbers/src/assertions.ts
@@ -1,7 +1,29 @@
 import { SOLANA_ERROR__CODECS__NUMBER_OUT_OF_RANGE, SolanaError } from '@solana/errors';
 
 /**
- * Asserts that a given number is between a given range.
+ * Ensures that a given number falls within a specified range.
+ *
+ * If the number is outside the allowed range, an error is thrown.
+ * This function is primarily used to validate values before encoding them in a codec.
+ *
+ * @param codecDescription - A string describing the codec that is performing the validation.
+ * @param min - The minimum allowed value (inclusive).
+ * @param max - The maximum allowed value (inclusive).
+ * @param value - The number to validate.
+ *
+ * @throws {@link SolanaError} if the value is out of range.
+ *
+ * @example
+ * Validating a number within range.
+ * ```ts
+ * assertNumberIsBetweenForCodec('u8', 0, 255, 42); // Passes
+ * ```
+ *
+ * @example
+ * Throwing an error for an out-of-range value.
+ * ```ts
+ * assertNumberIsBetweenForCodec('u8', 0, 255, 300); // Throws
+ * ```
  */
 export function assertNumberIsBetweenForCodec(
     codecDescription: string,

--- a/packages/codecs-numbers/src/common.ts
+++ b/packages/codecs-numbers/src/common.ts
@@ -1,37 +1,93 @@
 import { Codec, Decoder, Encoder, FixedSizeCodec, FixedSizeDecoder, FixedSizeEncoder } from '@solana/codecs-core';
-
-/** Defines a encoder for numbers and bigints. */
+/**
+ * Represents an encoder for numbers and bigints.
+ *
+ * This type allows encoding values that are either `number` or `bigint`.
+ * Depending on the specific implementation, the encoded output may have a fixed or variable size.
+ *
+ * @see {@link FixedSizeNumberEncoder}
+ */
 export type NumberEncoder = Encoder<bigint | number>;
 
-/** Defines a fixed-size encoder for numbers and bigints. */
+/**
+ * Represents a fixed-size encoder for numbers and bigints.
+ *
+ * This encoder serializes values using an exact number of bytes, defined by `TSize`.
+ *
+ * @typeParam TSize - The number of bytes used for encoding.
+ *
+ * @see {@link NumberEncoder}
+ */
 export type FixedSizeNumberEncoder<TSize extends number = number> = FixedSizeEncoder<bigint | number, TSize>;
 
-/** Defines a decoder for numbers and bigints. */
+/**
+ * Represents a decoder for numbers and bigints.
+ *
+ * This type supports decoding values as either `number` or `bigint`, depending on the implementation.
+ *
+ * @see {@link FixedSizeNumberDecoder}
+ */
 export type NumberDecoder = Decoder<bigint> | Decoder<number>;
 
-/** Defines a fixed-size decoder for numbers and bigints. */
+/**
+ * Represents a fixed-size decoder for numbers and bigints.
+ *
+ * This decoder reads a fixed number of bytes (`TSize`) and converts them into a `number` or `bigint`.
+ *
+ * @typeParam TSize - The number of bytes expected for decoding.
+ *
+ * @see {@link NumberDecoder}
+ */
 export type FixedSizeNumberDecoder<TSize extends number = number> =
     | FixedSizeDecoder<bigint, TSize>
     | FixedSizeDecoder<number, TSize>;
 
-/** Defines a codec for numbers and bigints. */
+/**
+ * Represents a codec for encoding and decoding numbers and bigints.
+ *
+ * - The encoded value can be either a `number` or a `bigint`.
+ * - The decoded value will always be either a `number` or `bigint`, depending on the implementation.
+ *
+ * @see {@link FixedSizeNumberCodec}
+ */
 export type NumberCodec = Codec<bigint | number, bigint> | Codec<bigint | number, number>;
 
-/** Defines a fixed-size codec for numbers and bigints. */
+/**
+ * Represents a fixed-size codec for encoding and decoding numbers and bigints.
+ *
+ * This codec uses a specific number of bytes (`TSize`) for serialization.
+ * The encoded value can be either a `number` or `bigint`, but the decoded value will always be a `number` or `bigint`,
+ * depending on the implementation.
+ *
+ * @typeParam TSize - The number of bytes used for encoding and decoding.
+ *
+ * @see {@link NumberCodec}
+ */
 export type FixedSizeNumberCodec<TSize extends number = number> =
     | FixedSizeCodec<bigint | number, bigint, TSize>
     | FixedSizeCodec<bigint | number, number, TSize>;
 
-/** Defines the config for number codecs that use more than one byte. */
+/**
+ * Configuration options for number codecs that use more than one byte.
+ *
+ * This configuration applies to all number codecs except `u8` and `i8`,
+ * allowing the user to specify the endianness of serialization.
+ */
 export type NumberCodecConfig = {
     /**
-     * Whether the serializer should use little-endian or big-endian encoding.
+     * Specifies whether numbers should be encoded in little-endian or big-endian format.
+     *
      * @defaultValue `Endian.Little`
      */
     endian?: Endian;
 };
 
-/** Defines the endianness of a number serializer. */
+/**
+ * Defines the byte order used for number serialization.
+ *
+ * - `Little`: The least significant byte is stored first.
+ * - `Big`: The most significant byte is stored first.
+ */
 export enum Endian {
     Little,
     Big,

--- a/packages/codecs-numbers/src/f32.ts
+++ b/packages/codecs-numbers/src/f32.ts
@@ -3,6 +3,26 @@ import { combineCodec, FixedSizeCodec, FixedSizeDecoder, FixedSizeEncoder } from
 import { NumberCodecConfig } from './common';
 import { numberDecoderFactory, numberEncoderFactory } from './utils';
 
+/**
+ * Returns an encoder for 32-bit floating-point numbers (`f32`).
+ *
+ * This encoder serializes `f32` values using 4 bytes.
+ * Floating-point values may lose precision when encoded.
+ *
+ * For more details, see {@link getF32Codec}.
+ *
+ * @param config - Optional configuration to specify endianness (little by default).
+ * @returns A `FixedSizeEncoder<number, 4>` for encoding `f32` values.
+ *
+ * @example
+ * Encoding an `f32` value.
+ * ```ts
+ * const encoder = getF32Encoder();
+ * const bytes = encoder.encode(-1.5); // 0x0000c0bf
+ * ```
+ *
+ * @see {@link getF32Codec}
+ */
 export const getF32Encoder = (config: NumberCodecConfig = {}): FixedSizeEncoder<bigint | number, 4> =>
     numberEncoderFactory({
         config,
@@ -11,6 +31,26 @@ export const getF32Encoder = (config: NumberCodecConfig = {}): FixedSizeEncoder<
         size: 4,
     });
 
+/**
+ * Returns a decoder for 32-bit floating-point numbers (`f32`).
+ *
+ * This decoder deserializes `f32` values from 4 bytes.
+ * Some precision may be lost during decoding due to floating-point representation.
+ *
+ * For more details, see {@link getF32Codec}.
+ *
+ * @param config - Optional configuration to specify endianness (little by default).
+ * @returns A `FixedSizeDecoder<number, 4>` for decoding `f32` values.
+ *
+ * @example
+ * Decoding an `f32` value.
+ * ```ts
+ * const decoder = getF32Decoder();
+ * const value = decoder.decode(new Uint8Array([0x00, 0x00, 0xc0, 0xbf])); // -1.5
+ * ```
+ *
+ * @see {@link getF32Codec}
+ */
 export const getF32Decoder = (config: NumberCodecConfig = {}): FixedSizeDecoder<number, 4> =>
     numberDecoderFactory({
         config,
@@ -19,5 +59,46 @@ export const getF32Decoder = (config: NumberCodecConfig = {}): FixedSizeDecoder<
         size: 4,
     });
 
+/**
+ * Returns a codec for encoding and decoding 32-bit floating-point numbers (`f32`).
+ *
+ * This codec serializes `f32` values using 4 bytes.
+ * Due to the IEEE 754 floating-point representation, some precision loss may occur.
+ *
+ * @param config - Optional configuration to specify endianness (little by default).
+ * @returns A `FixedSizeCodec<number, number, 4>` for encoding and decoding `f32` values.
+ *
+ * @example
+ * Encoding and decoding an `f32` value.
+ * ```ts
+ * const codec = getF32Codec();
+ * const bytes = codec.encode(-1.5); // 0x0000c0bf
+ * const value = codec.decode(bytes); // -1.5
+ * ```
+ *
+ * @example
+ * Using big-endian encoding.
+ * ```ts
+ * const codec = getF32Codec({ endian: Endian.Big });
+ * const bytes = codec.encode(-1.5); // 0xbfc00000
+ * ```
+ *
+ * @remarks
+ * `f32` values follow the IEEE 754 single-precision floating-point standard.
+ * Precision loss may occur for certain values.
+ *
+ * - If you need higher precision, consider using {@link getF64Codec}.
+ * - If you need integer values, consider using {@link getI32Codec} or {@link getU32Codec}.
+ *
+ * Separate {@link getF32Encoder} and {@link getF32Decoder} functions are available.
+ *
+ * ```ts
+ * const bytes = getF32Encoder().encode(-1.5);
+ * const value = getF32Decoder().decode(bytes);
+ * ```
+ *
+ * @see {@link getF32Encoder}
+ * @see {@link getF32Decoder}
+ */
 export const getF32Codec = (config: NumberCodecConfig = {}): FixedSizeCodec<bigint | number, number, 4> =>
     combineCodec(getF32Encoder(config), getF32Decoder(config));

--- a/packages/codecs-numbers/src/f64.ts
+++ b/packages/codecs-numbers/src/f64.ts
@@ -3,6 +3,26 @@ import { combineCodec, FixedSizeCodec, FixedSizeDecoder, FixedSizeEncoder } from
 import { NumberCodecConfig } from './common';
 import { numberDecoderFactory, numberEncoderFactory } from './utils';
 
+/**
+ * Returns an encoder for 64-bit floating-point numbers (`f64`).
+ *
+ * This encoder serializes `f64` values using 8 bytes.
+ * Floating-point values may lose precision when encoded.
+ *
+ * For more details, see {@link getF64Codec}.
+ *
+ * @param config - Optional configuration to specify endianness (little by default).
+ * @returns A `FixedSizeEncoder<number, 8>` for encoding `f64` values.
+ *
+ * @example
+ * Encoding an `f64` value.
+ * ```ts
+ * const encoder = getF64Encoder();
+ * const bytes = encoder.encode(-1.5); // 0x000000000000f8bf
+ * ```
+ *
+ * @see {@link getF64Codec}
+ */
 export const getF64Encoder = (config: NumberCodecConfig = {}): FixedSizeEncoder<bigint | number, 8> =>
     numberEncoderFactory({
         config,
@@ -11,6 +31,26 @@ export const getF64Encoder = (config: NumberCodecConfig = {}): FixedSizeEncoder<
         size: 8,
     });
 
+/**
+ * Returns a decoder for 64-bit floating-point numbers (`f64`).
+ *
+ * This decoder deserializes `f64` values from 8 bytes.
+ * Some precision may be lost during decoding due to floating-point representation.
+ *
+ * For more details, see {@link getF64Codec}.
+ *
+ * @param config - Optional configuration to specify endianness (little by default).
+ * @returns A `FixedSizeDecoder<number, 8>` for decoding `f64` values.
+ *
+ * @example
+ * Decoding an `f64` value.
+ * ```ts
+ * const decoder = getF64Decoder();
+ * const value = decoder.decode(new Uint8Array([0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0xf8, 0xbf])); // -1.5
+ * ```
+ *
+ * @see {@link getF64Codec}
+ */
 export const getF64Decoder = (config: NumberCodecConfig = {}): FixedSizeDecoder<number, 8> =>
     numberDecoderFactory({
         config,
@@ -19,5 +59,46 @@ export const getF64Decoder = (config: NumberCodecConfig = {}): FixedSizeDecoder<
         size: 8,
     });
 
+/**
+ * Returns a codec for encoding and decoding 64-bit floating-point numbers (`f64`).
+ *
+ * This codec serializes `f64` values using 8 bytes.
+ * Due to the IEEE 754 floating-point representation, some precision loss may occur.
+ *
+ * @param config - Optional configuration to specify endianness (little by default).
+ * @returns A `FixedSizeCodec<number, number, 8>` for encoding and decoding `f64` values.
+ *
+ * @example
+ * Encoding and decoding an `f64` value.
+ * ```ts
+ * const codec = getF64Codec();
+ * const bytes = codec.encode(-1.5); // 0x000000000000f8bf
+ * const value = codec.decode(bytes); // -1.5
+ * ```
+ *
+ * @example
+ * Using big-endian encoding.
+ * ```ts
+ * const codec = getF64Codec({ endian: Endian.Big });
+ * const bytes = codec.encode(-1.5); // 0xbff8000000000000
+ * ```
+ *
+ * @remarks
+ * `f64` values follow the IEEE 754 double-precision floating-point standard.
+ * Precision loss may still occur but is significantly lower than `f32`.
+ *
+ * - If you need smaller floating-point values, consider using {@link getF32Codec}.
+ * - If you need integer values, consider using {@link getI64Codec} or {@link getU64Codec}.
+ *
+ * Separate {@link getF64Encoder} and {@link getF64Decoder} functions are available.
+ *
+ * ```ts
+ * const bytes = getF64Encoder().encode(-1.5);
+ * const value = getF64Decoder().decode(bytes);
+ * ```
+ *
+ * @see {@link getF64Encoder}
+ * @see {@link getF64Decoder}
+ */
 export const getF64Codec = (config: NumberCodecConfig = {}): FixedSizeCodec<bigint | number, number, 8> =>
     combineCodec(getF64Encoder(config), getF64Decoder(config));

--- a/packages/codecs-numbers/src/i128.ts
+++ b/packages/codecs-numbers/src/i128.ts
@@ -3,6 +3,26 @@ import { combineCodec, FixedSizeCodec, FixedSizeDecoder, FixedSizeEncoder } from
 import { NumberCodecConfig } from './common';
 import { numberDecoderFactory, numberEncoderFactory } from './utils';
 
+/**
+ * Returns an encoder for 128-bit signed integers (`i128`).
+ *
+ * This encoder serializes `i128` values using 16 bytes.
+ * Values can be provided as either `number` or `bigint`.
+ *
+ * For more details, see {@link getI128Codec}.
+ *
+ * @param config - Optional configuration to specify endianness (little by default).
+ * @returns A `FixedSizeEncoder<number | bigint, 16>` for encoding `i128` values.
+ *
+ * @example
+ * Encoding an `i128` value.
+ * ```ts
+ * const encoder = getI128Encoder();
+ * const bytes = encoder.encode(-42n); // 0xd6ffffffffffffffffffffffffffffff
+ * ```
+ *
+ * @see {@link getI128Codec}
+ */
 export const getI128Encoder = (config: NumberCodecConfig = {}): FixedSizeEncoder<bigint | number, 16> =>
     numberEncoderFactory({
         config,
@@ -18,6 +38,29 @@ export const getI128Encoder = (config: NumberCodecConfig = {}): FixedSizeEncoder
         size: 16,
     });
 
+/**
+ * Returns a decoder for 128-bit signed integers (`i128`).
+ *
+ * This decoder deserializes `i128` values from 16 bytes.
+ * The decoded value is always a `bigint`.
+ *
+ * For more details, see {@link getI128Codec}.
+ *
+ * @param config - Optional configuration to specify endianness (little by default).
+ * @returns A `FixedSizeDecoder<bigint, 16>` for decoding `i128` values.
+ *
+ * @example
+ * Decoding an `i128` value.
+ * ```ts
+ * const decoder = getI128Decoder();
+ * const value = decoder.decode(new Uint8Array([
+ *   0xd6, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff,
+ *   0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff
+ * ])); // -42n
+ * ```
+ *
+ * @see {@link getI128Codec}
+ */
 export const getI128Decoder = (config: NumberCodecConfig = {}): FixedSizeDecoder<bigint, 16> =>
     numberDecoderFactory({
         config,
@@ -32,5 +75,47 @@ export const getI128Decoder = (config: NumberCodecConfig = {}): FixedSizeDecoder
         size: 16,
     });
 
+/**
+ * Returns a codec for encoding and decoding 128-bit signed integers (`i128`).
+ *
+ * This codec serializes `i128` values using 16 bytes.
+ * Values can be provided as either `number` or `bigint`, but the decoded value is always a `bigint`.
+ *
+ * @param config - Optional configuration to specify endianness (little by default).
+ * @returns A `FixedSizeCodec<number | bigint, bigint, 16>` for encoding and decoding `i128` values.
+ *
+ * @example
+ * Encoding and decoding an `i128` value.
+ * ```ts
+ * const codec = getI128Codec();
+ * const bytes = codec.encode(-42n); // 0xd6ffffffffffffffffffffffffffffff
+ * const value = codec.decode(bytes); // -42n
+ * ```
+ *
+ * @example
+ * Using big-endian encoding.
+ * ```ts
+ * const codec = getI128Codec({ endian: Endian.Big });
+ * const bytes = codec.encode(-42n); // 0xffffffffffffffffffffffffffffd6
+ * ```
+ *
+ * @remarks
+ * This codec supports values between `-2^127` and `2^127 - 1`.
+ * Since JavaScript `number` cannot safely represent values beyond `2^53 - 1`, the decoded value is always a `bigint`.
+ *
+ * - If you need a smaller signed integer, consider using {@link getI64Codec} or {@link getI32Codec}.
+ * - If you need a larger signed integer, consider using a custom codec.
+ * - If you need unsigned integers, consider using {@link getU128Codec}.
+ *
+ * Separate {@link getI128Encoder} and {@link getI128Decoder} functions are available.
+ *
+ * ```ts
+ * const bytes = getI128Encoder().encode(-42);
+ * const value = getI128Decoder().decode(bytes);
+ * ```
+ *
+ * @see {@link getI128Encoder}
+ * @see {@link getI128Decoder}
+ */
 export const getI128Codec = (config: NumberCodecConfig = {}): FixedSizeCodec<bigint | number, bigint, 16> =>
     combineCodec(getI128Encoder(config), getI128Decoder(config));

--- a/packages/codecs-numbers/src/i16.ts
+++ b/packages/codecs-numbers/src/i16.ts
@@ -3,6 +3,26 @@ import { combineCodec, FixedSizeCodec, FixedSizeDecoder, FixedSizeEncoder } from
 import { NumberCodecConfig } from './common';
 import { numberDecoderFactory, numberEncoderFactory } from './utils';
 
+/**
+ * Returns an encoder for 16-bit signed integers (`i16`).
+ *
+ * This encoder serializes `i16` values using 2 bytes.
+ * Values can be provided as either `number` or `bigint`.
+ *
+ * For more details, see {@link getI16Codec}.
+ *
+ * @param config - Optional configuration to specify endianness (little by default).
+ * @returns A `FixedSizeEncoder<number | bigint, 2>` for encoding `i16` values.
+ *
+ * @example
+ * Encoding an `i16` value.
+ * ```ts
+ * const encoder = getI16Encoder();
+ * const bytes = encoder.encode(-42); // 0xd6ff
+ * ```
+ *
+ * @see {@link getI16Codec}
+ */
 export const getI16Encoder = (config: NumberCodecConfig = {}): FixedSizeEncoder<bigint | number, 2> =>
     numberEncoderFactory({
         config,
@@ -12,6 +32,26 @@ export const getI16Encoder = (config: NumberCodecConfig = {}): FixedSizeEncoder<
         size: 2,
     });
 
+/**
+ * Returns a decoder for 16-bit signed integers (`i16`).
+ *
+ * This decoder deserializes `i16` values from 2 bytes.
+ * The decoded value is always a `number`.
+ *
+ * For more details, see {@link getI16Codec}.
+ *
+ * @param config - Optional configuration to specify endianness (little by default).
+ * @returns A `FixedSizeDecoder<number, 2>` for decoding `i16` values.
+ *
+ * @example
+ * Decoding an `i16` value.
+ * ```ts
+ * const decoder = getI16Decoder();
+ * const value = decoder.decode(new Uint8Array([0xd6, 0xff])); // -42
+ * ```
+ *
+ * @see {@link getI16Codec}
+ */
 export const getI16Decoder = (config: NumberCodecConfig = {}): FixedSizeDecoder<number, 2> =>
     numberDecoderFactory({
         config,
@@ -20,5 +60,46 @@ export const getI16Decoder = (config: NumberCodecConfig = {}): FixedSizeDecoder<
         size: 2,
     });
 
+/**
+ * Returns a codec for encoding and decoding 16-bit signed integers (`i16`).
+ *
+ * This codec serializes `i16` values using 2 bytes.
+ * Values can be provided as either `number` or `bigint`, but the decoded value is always a `number`.
+ *
+ * @param config - Optional configuration to specify endianness (little by default).
+ * @returns A `FixedSizeCodec<number | bigint, number, 2>` for encoding and decoding `i16` values.
+ *
+ * @example
+ * Encoding and decoding an `i16` value.
+ * ```ts
+ * const codec = getI16Codec();
+ * const bytes = codec.encode(-42); // 0xd6ff
+ * const value = codec.decode(bytes); // -42
+ * ```
+ *
+ * @example
+ * Using big-endian encoding.
+ * ```ts
+ * const codec = getI16Codec({ endian: Endian.Big });
+ * const bytes = codec.encode(-42); // 0xffd6
+ * ```
+ *
+ * @remarks
+ * This codec supports values between `-2^15` (`-32,768`) and `2^15 - 1` (`32,767`).
+ *
+ * - If you need a smaller signed integer, consider using {@link getI8Codec}.
+ * - If you need a larger signed integer, consider using {@link getI32Codec}.
+ * - If you need unsigned integers, consider using {@link getU16Codec}.
+ *
+ * Separate {@link getI16Encoder} and {@link getI16Decoder} functions are available.
+ *
+ * ```ts
+ * const bytes = getI16Encoder().encode(-42);
+ * const value = getI16Decoder().decode(bytes);
+ * ```
+ *
+ * @see {@link getI16Encoder}
+ * @see {@link getI16Decoder}
+ */
 export const getI16Codec = (config: NumberCodecConfig = {}): FixedSizeCodec<bigint | number, number, 2> =>
     combineCodec(getI16Encoder(config), getI16Decoder(config));

--- a/packages/codecs-numbers/src/i32.ts
+++ b/packages/codecs-numbers/src/i32.ts
@@ -3,6 +3,26 @@ import { combineCodec, FixedSizeCodec, FixedSizeDecoder, FixedSizeEncoder } from
 import { NumberCodecConfig } from './common';
 import { numberDecoderFactory, numberEncoderFactory } from './utils';
 
+/**
+ * Returns an encoder for 32-bit signed integers (`i32`).
+ *
+ * This encoder serializes `i32` values using 4 bytes.
+ * Values can be provided as either `number` or `bigint`.
+ *
+ * For more details, see {@link getI32Codec}.
+ *
+ * @param config - Optional configuration to specify endianness (little by default).
+ * @returns A `FixedSizeEncoder<number | bigint, 4>` for encoding `i32` values.
+ *
+ * @example
+ * Encoding an `i32` value.
+ * ```ts
+ * const encoder = getI32Encoder();
+ * const bytes = encoder.encode(-42); // 0xd6ffffff
+ * ```
+ *
+ * @see {@link getI32Codec}
+ */
 export const getI32Encoder = (config: NumberCodecConfig = {}): FixedSizeEncoder<bigint | number, 4> =>
     numberEncoderFactory({
         config,
@@ -12,6 +32,26 @@ export const getI32Encoder = (config: NumberCodecConfig = {}): FixedSizeEncoder<
         size: 4,
     });
 
+/**
+ * Returns a decoder for 32-bit signed integers (`i32`).
+ *
+ * This decoder deserializes `i32` values from 4 bytes.
+ * The decoded value is always a `number`.
+ *
+ * For more details, see {@link getI32Codec}.
+ *
+ * @param config - Optional configuration to specify endianness (little by default).
+ * @returns A `FixedSizeDecoder<number, 4>` for decoding `i32` values.
+ *
+ * @example
+ * Decoding an `i32` value.
+ * ```ts
+ * const decoder = getI32Decoder();
+ * const value = decoder.decode(new Uint8Array([0xd6, 0xff, 0xff, 0xff])); // -42
+ * ```
+ *
+ * @see {@link getI32Codec}
+ */
 export const getI32Decoder = (config: NumberCodecConfig = {}): FixedSizeDecoder<number, 4> =>
     numberDecoderFactory({
         config,
@@ -20,5 +60,46 @@ export const getI32Decoder = (config: NumberCodecConfig = {}): FixedSizeDecoder<
         size: 4,
     });
 
+/**
+ * Returns a codec for encoding and decoding 32-bit signed integers (`i32`).
+ *
+ * This codec serializes `i32` values using 4 bytes.
+ * Values can be provided as either `number` or `bigint`, but the decoded value is always a `number`.
+ *
+ * @param config - Optional configuration to specify endianness (little by default).
+ * @returns A `FixedSizeCodec<number | bigint, number, 4>` for encoding and decoding `i32` values.
+ *
+ * @example
+ * Encoding and decoding an `i32` value.
+ * ```ts
+ * const codec = getI32Codec();
+ * const bytes = codec.encode(-42); // 0xd6ffffff
+ * const value = codec.decode(bytes); // -42
+ * ```
+ *
+ * @example
+ * Using big-endian encoding.
+ * ```ts
+ * const codec = getI32Codec({ endian: Endian.Big });
+ * const bytes = codec.encode(-42); // 0xffffffd6
+ * ```
+ *
+ * @remarks
+ * This codec supports values between `-2^31` (`-2,147,483,648`) and `2^31 - 1` (`2,147,483,647`).
+ *
+ * - If you need a smaller signed integer, consider using {@link getI16Codec} or {@link getI8Codec}.
+ * - If you need a larger signed integer, consider using {@link getI64Codec}.
+ * - If you need unsigned integers, consider using {@link getU32Codec}.
+ *
+ * Separate {@link getI32Encoder} and {@link getI32Decoder} functions are available.
+ *
+ * ```ts
+ * const bytes = getI32Encoder().encode(-42);
+ * const value = getI32Decoder().decode(bytes);
+ * ```
+ *
+ * @see {@link getI32Encoder}
+ * @see {@link getI32Decoder}
+ */
 export const getI32Codec = (config: NumberCodecConfig = {}): FixedSizeCodec<bigint | number, number, 4> =>
     combineCodec(getI32Encoder(config), getI32Decoder(config));

--- a/packages/codecs-numbers/src/i64.ts
+++ b/packages/codecs-numbers/src/i64.ts
@@ -3,6 +3,26 @@ import { combineCodec, FixedSizeCodec, FixedSizeDecoder, FixedSizeEncoder } from
 import { NumberCodecConfig } from './common';
 import { numberDecoderFactory, numberEncoderFactory } from './utils';
 
+/**
+ * Returns an encoder for 64-bit signed integers (`i64`).
+ *
+ * This encoder serializes `i64` values using 8 bytes.
+ * Values can be provided as either `number` or `bigint`.
+ *
+ * For more details, see {@link getI64Codec}.
+ *
+ * @param config - Optional configuration to specify endianness (little by default).
+ * @returns A `FixedSizeEncoder<number | bigint, 8>` for encoding `i64` values.
+ *
+ * @example
+ * Encoding an `i64` value.
+ * ```ts
+ * const encoder = getI64Encoder();
+ * const bytes = encoder.encode(-42n); // 0xd6ffffffffffffff
+ * ```
+ *
+ * @see {@link getI64Codec}
+ */
 export const getI64Encoder = (config: NumberCodecConfig = {}): FixedSizeEncoder<bigint | number, 8> =>
     numberEncoderFactory({
         config,
@@ -12,6 +32,28 @@ export const getI64Encoder = (config: NumberCodecConfig = {}): FixedSizeEncoder<
         size: 8,
     });
 
+/**
+ * Returns a decoder for 64-bit signed integers (`i64`).
+ *
+ * This decoder deserializes `i64` values from 8 bytes.
+ * The decoded value is always a `bigint`.
+ *
+ * For more details, see {@link getI64Codec}.
+ *
+ * @param config - Optional configuration to specify endianness (little by default).
+ * @returns A `FixedSizeDecoder<bigint, 8>` for decoding `i64` values.
+ *
+ * @example
+ * Decoding an `i64` value.
+ * ```ts
+ * const decoder = getI64Decoder();
+ * const value = decoder.decode(new Uint8Array([
+ *   0xd6, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff
+ * ])); // -42n
+ * ```
+ *
+ * @see {@link getI64Codec}
+ */
 export const getI64Decoder = (config: NumberCodecConfig = {}): FixedSizeDecoder<bigint, 8> =>
     numberDecoderFactory({
         config,
@@ -20,5 +62,47 @@ export const getI64Decoder = (config: NumberCodecConfig = {}): FixedSizeDecoder<
         size: 8,
     });
 
+/**
+ * Returns a codec for encoding and decoding 64-bit signed integers (`i64`).
+ *
+ * This codec serializes `i64` values using 8 bytes.
+ * Values can be provided as either `number` or `bigint`, but the decoded value is always a `bigint`.
+ *
+ * @param config - Optional configuration to specify endianness (little by default).
+ * @returns A `FixedSizeCodec<number | bigint, bigint, 8>` for encoding and decoding `i64` values.
+ *
+ * @example
+ * Encoding and decoding an `i64` value.
+ * ```ts
+ * const codec = getI64Codec();
+ * const bytes = codec.encode(-42n); // 0xd6ffffffffffffff
+ * const value = codec.decode(bytes); // -42n
+ * ```
+ *
+ * @example
+ * Using big-endian encoding.
+ * ```ts
+ * const codec = getI64Codec({ endian: Endian.Big });
+ * const bytes = codec.encode(-42n); // 0xffffffffffffffd6
+ * ```
+ *
+ * @remarks
+ * This codec supports values between `-2^63` and `2^63 - 1`.
+ * Since JavaScript `number` cannot safely represent values beyond `2^53 - 1`, the decoded value is always a `bigint`.
+ *
+ * - If you need a smaller signed integer, consider using {@link getI32Codec} or {@link getI16Codec}.
+ * - If you need a larger signed integer, consider using {@link getI128Codec}.
+ * - If you need unsigned integers, consider using {@link getU64Codec}.
+ *
+ * Separate {@link getI64Encoder} and {@link getI64Decoder} functions are available.
+ *
+ * ```ts
+ * const bytes = getI64Encoder().encode(-42);
+ * const value = getI64Decoder().decode(bytes);
+ * ```
+ *
+ * @see {@link getI64Encoder}
+ * @see {@link getI64Decoder}
+ */
 export const getI64Codec = (config: NumberCodecConfig = {}): FixedSizeCodec<bigint | number, bigint, 8> =>
     combineCodec(getI64Encoder(config), getI64Decoder(config));

--- a/packages/codecs-numbers/src/i8.ts
+++ b/packages/codecs-numbers/src/i8.ts
@@ -2,6 +2,25 @@ import { combineCodec, FixedSizeCodec, FixedSizeDecoder, FixedSizeEncoder } from
 
 import { numberDecoderFactory, numberEncoderFactory } from './utils';
 
+/**
+ * Returns an encoder for 8-bit signed integers (`i8`).
+ *
+ * This encoder serializes `i8` values using 1 byte.
+ * Values can be provided as either `number` or `bigint`.
+ *
+ * For more details, see {@link getI8Codec}.
+ *
+ * @returns A `FixedSizeEncoder<number | bigint, 1>` for encoding `i8` values.
+ *
+ * @example
+ * Encoding an `i8` value.
+ * ```ts
+ * const encoder = getI8Encoder();
+ * const bytes = encoder.encode(-42); // 0xd6
+ * ```
+ *
+ * @see {@link getI8Codec}
+ */
 export const getI8Encoder = (): FixedSizeEncoder<bigint | number, 1> =>
     numberEncoderFactory({
         name: 'i8',
@@ -10,6 +29,25 @@ export const getI8Encoder = (): FixedSizeEncoder<bigint | number, 1> =>
         size: 1,
     });
 
+/**
+ * Returns a decoder for 8-bit signed integers (`i8`).
+ *
+ * This decoder deserializes `i8` values from 1 byte.
+ * The decoded value is always a `number`.
+ *
+ * For more details, see {@link getI8Codec}.
+ *
+ * @returns A `FixedSizeDecoder<number, 1>` for decoding `i8` values.
+ *
+ * @example
+ * Decoding an `i8` value.
+ * ```ts
+ * const decoder = getI8Decoder();
+ * const value = decoder.decode(new Uint8Array([0xd6])); // -42
+ * ```
+ *
+ * @see {@link getI8Codec}
+ */
 export const getI8Decoder = (): FixedSizeDecoder<number, 1> =>
     numberDecoderFactory({
         get: view => view.getInt8(0),
@@ -17,5 +55,37 @@ export const getI8Decoder = (): FixedSizeDecoder<number, 1> =>
         size: 1,
     });
 
+/**
+ * Returns a codec for encoding and decoding 8-bit signed integers (`i8`).
+ *
+ * This codec serializes `i8` values using 1 byte.
+ * Values can be provided as either `number` or `bigint`, but the decoded value is always a `number`.
+ *
+ * @returns A `FixedSizeCodec<number | bigint, number, 1>` for encoding and decoding `i8` values.
+ *
+ * @example
+ * Encoding and decoding an `i8` value.
+ * ```ts
+ * const codec = getI8Codec();
+ * const bytes = codec.encode(-42); // 0xd6
+ * const value = codec.decode(bytes); // -42
+ * ```
+ *
+ * @remarks
+ * This codec supports values between `-2^7` (`-128`) and `2^7 - 1` (`127`).
+ *
+ * - If you need a larger signed integer, consider using {@link getI16Codec}.
+ * - If you need an unsigned integer, consider using {@link getU8Codec}.
+ *
+ * Separate {@link getI8Encoder} and {@link getI8Decoder} functions are available.
+ *
+ * ```ts
+ * const bytes = getI8Encoder().encode(-42);
+ * const value = getI8Decoder().decode(bytes);
+ * ```
+ *
+ * @see {@link getI8Encoder}
+ * @see {@link getI8Decoder}
+ */
 export const getI8Codec = (): FixedSizeCodec<bigint | number, number, 1> =>
     combineCodec(getI8Encoder(), getI8Decoder());

--- a/packages/codecs-numbers/src/index.ts
+++ b/packages/codecs-numbers/src/index.ts
@@ -1,3 +1,13 @@
+/**
+ * This package contains codecs for numbers of different sizes and endianness.
+ * It can be used standalone, but it is also exported as part of the Solana JavaScript SDK
+ * [`@solana/web3.js@next`](https://github.com/anza-xyz/solana-web3.js/tree/main/packages/library).
+ *
+ * This package is also part of the [`@solana/codecs` package](https://github.com/anza-xyz/solana-web3.js/tree/main/packages/codecs)
+ * which acts as an entry point for all codec packages as well as for their documentation.
+ *
+ * @packageDocumentation
+ */
 export * from './assertions';
 export * from './common';
 export * from './f32';

--- a/packages/codecs-numbers/src/short-u16.ts
+++ b/packages/codecs-numbers/src/short-u16.ts
@@ -12,8 +12,25 @@ import {
 import { assertNumberIsBetweenForCodec } from './assertions';
 
 /**
- * Encodes short u16 numbers.
- * @see {@link getShortU16Codec} for a more detailed description.
+ * Returns an encoder for `shortU16` values.
+ *
+ * This encoder serializes `shortU16` values using **1 to 3 bytes**.
+ * Smaller values use fewer bytes, while larger values take up more space.
+ *
+ * For more details, see {@link getShortU16Codec}.
+ *
+ * @returns A `VariableSizeEncoder<number | bigint>` for encoding `shortU16` values.
+ *
+ * @example
+ * Encoding a `shortU16` value.
+ * ```ts
+ * const encoder = getShortU16Encoder();
+ * encoder.encode(42);    // 0x2a
+ * encoder.encode(128);   // 0x8001
+ * encoder.encode(16384); // 0x808001
+ * ```
+ *
+ * @see {@link getShortU16Codec}
  */
 export const getShortU16Encoder = (): VariableSizeEncoder<bigint | number> =>
     createEncoder({
@@ -47,8 +64,25 @@ export const getShortU16Encoder = (): VariableSizeEncoder<bigint | number> =>
     });
 
 /**
- * Decodes short u16 numbers.
- * @see {@link getShortU16Codec} for a more detailed description.
+ * Returns a decoder for `shortU16` values.
+ *
+ * This decoder deserializes `shortU16` values from **1 to 3 bytes**.
+ * The number of bytes used depends on the encoded value.
+ *
+ * For more details, see {@link getShortU16Codec}.
+ *
+ * @returns A `VariableSizeDecoder<number>` for decoding `shortU16` values.
+ *
+ * @example
+ * Decoding a `shortU16` value.
+ * ```ts
+ * const decoder = getShortU16Decoder();
+ * decoder.decode(new Uint8Array([0x2a]));             // 42
+ * decoder.decode(new Uint8Array([0x80, 0x01]));       // 128
+ * decoder.decode(new Uint8Array([0x80, 0x80, 0x01])); // 16384
+ * ```
+ *
+ * @see {@link getShortU16Codec}
  */
 export const getShortU16Decoder = (): VariableSizeDecoder<number> =>
     createDecoder({
@@ -72,13 +106,53 @@ export const getShortU16Decoder = (): VariableSizeDecoder<number> =>
     });
 
 /**
- * Encodes and decodes short u16 numbers.
+ * Returns a codec for encoding and decoding `shortU16` values.
  *
- * Short u16 numbers are the same as u16, but serialized with 1 to 3 bytes.
- * If the value is above 0x7f, the top bit is set and the remaining
- * value is stored in the next bytes. Each byte follows the same
- * pattern until the 3rd byte. The 3rd byte, if needed, uses
- * all 8 bits to store the last byte of the original value.
+ * It serializes unsigned integers using **1 to 3 bytes** based on the encoded value.
+ * The larger the value, the more bytes it uses.
+ *
+ * - If the value is `<= 0x7f` (127), it is stored in a **single byte**
+ *   and the first bit is set to `0` to indicate the end of the value.
+ * - Otherwise, the first bit is set to `1` to indicate that the value continues in the next byte, which follows the same pattern.
+ * - This process repeats until the value is fully encoded in up to 3 bytes. The third and last byte, if needed, uses all 8 bits to store the remaining value.
+ *
+ * In other words, the encoding scheme follows this structure:
+ *
+ * ```txt
+ * 0XXXXXXX                   <- Values 0 to 127 (1 byte)
+ * 1XXXXXXX 0XXXXXXX          <- Values 128 to 16,383 (2 bytes)
+ * 1XXXXXXX 1XXXXXXX XXXXXXXX <- Values 16,384 to 4,194,303 (3 bytes)
+ * ```
+ *
+ * @returns A `VariableSizeCodec<number | bigint, number>` for encoding and decoding `shortU16` values.
+ *
+ * @example
+ * Encoding and decoding `shortU16` values.
+ * ```ts
+ * const codec = getShortU16Codec();
+ * const bytes1 = codec.encode(42);    // 0x2a
+ * const bytes2 = codec.encode(128);   // 0x8001
+ * const bytes3 = codec.encode(16384); // 0x808001
+ *
+ * codec.decode(bytes1); // 42
+ * codec.decode(bytes2); // 128
+ * codec.decode(bytes3); // 16384
+ * ```
+ *
+ * @remarks
+ * This codec efficiently stores small numbers, making it useful for transactions and compact representations.
+ *
+ * If you need a fixed-size `u16` codec, consider using {@link getU16Codec}.
+ *
+ * Separate {@link getShortU16Encoder} and {@link getShortU16Decoder} functions are available.
+ *
+ * ```ts
+ * const bytes = getShortU16Encoder().encode(42);
+ * const value = getShortU16Decoder().decode(bytes);
+ * ```
+ *
+ * @see {@link getShortU16Encoder}
+ * @see {@link getShortU16Decoder}
  */
 export const getShortU16Codec = (): VariableSizeCodec<bigint | number, number> =>
     combineCodec(getShortU16Encoder(), getShortU16Decoder());

--- a/packages/codecs-numbers/src/u128.ts
+++ b/packages/codecs-numbers/src/u128.ts
@@ -3,6 +3,26 @@ import { combineCodec, FixedSizeCodec, FixedSizeDecoder, FixedSizeEncoder } from
 import { NumberCodecConfig } from './common';
 import { numberDecoderFactory, numberEncoderFactory } from './utils';
 
+/**
+ * Returns an encoder for 128-bit unsigned integers (`u128`).
+ *
+ * This encoder serializes `u128` values using sixteen bytes in little-endian format by default.
+ * You may specify big-endian storage using the `endian` option.
+ *
+ * For more details, see {@link getU128Codec}.
+ *
+ * @param config - Optional settings for endianness.
+ * @returns A `FixedSizeEncoder<number | bigint, 16>` for encoding `u128` values.
+ *
+ * @example
+ * Encoding a `u128` value.
+ * ```ts
+ * const encoder = getU128Encoder();
+ * const bytes = encoder.encode(42n); // 0x2a000000000000000000000000000000
+ * ```
+ *
+ * @see {@link getU128Codec}
+ */
 export const getU128Encoder = (config: NumberCodecConfig = {}): FixedSizeEncoder<bigint | number, 16> =>
     numberEncoderFactory({
         config,
@@ -18,6 +38,26 @@ export const getU128Encoder = (config: NumberCodecConfig = {}): FixedSizeEncoder
         size: 16,
     });
 
+/**
+ * Returns a decoder for 128-bit unsigned integers (`u128`).
+ *
+ * This decoder deserializes `u128` values from sixteen bytes in little-endian format by default.
+ * You may specify big-endian storage using the `endian` option.
+ *
+ * For more details, see {@link getU128Codec}.
+ *
+ * @param config - Optional settings for endianness.
+ * @returns A `FixedSizeDecoder<bigint, 16>` for decoding `u128` values.
+ *
+ * @example
+ * Decoding a `u128` value.
+ * ```ts
+ * const decoder = getU128Decoder();
+ * const value = decoder.decode(new Uint8Array([0x2a, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00])); // 42n
+ * ```
+ *
+ * @see {@link getU128Codec}
+ */
 export const getU128Decoder = (config: NumberCodecConfig = {}): FixedSizeDecoder<bigint, 16> =>
     numberDecoderFactory({
         config,
@@ -32,5 +72,46 @@ export const getU128Decoder = (config: NumberCodecConfig = {}): FixedSizeDecoder
         size: 16,
     });
 
+/**
+ * Returns a codec for encoding and decoding 128-bit unsigned integers (`u128`).
+ *
+ * This codec serializes `u128` values using 16 bytes.
+ * Values can be provided as either `number` or `bigint`, but the decoded value is always a `bigint`.
+ *
+ * @param config - Optional configuration to specify endianness (little by default).
+ * @returns A `FixedSizeCodec<number | bigint, bigint, 16>` for encoding and decoding `u128` values.
+ *
+ * @example
+ * Encoding and decoding a `u128` value.
+ * ```ts
+ * const codec = getU128Codec();
+ * const bytes = codec.encode(42); // 0x2a000000000000000000000000000000
+ * const value = codec.decode(bytes); // 42n
+ * ```
+ *
+ * @example
+ * Using big-endian encoding.
+ * ```ts
+ * const codec = getU128Codec({ endian: Endian.Big });
+ * const bytes = codec.encode(42); // 0x0000000000000000000000000000002a
+ * ```
+ *
+ * @remarks
+ * This codec supports values between `0` and `2^128 - 1`.
+ * Since JavaScript `number` cannot safely represent values beyond `2^53 - 1`, the decoded value is always a `bigint`.
+ *
+ * - If you need a smaller unsigned integer, consider using {@link getU64Codec} or {@link getU32Codec}.
+ * - If you need signed integers, consider using {@link getI128Codec}.
+ *
+ * Separate {@link getU128Encoder} and {@link getU128Decoder} functions are available.
+ *
+ * ```ts
+ * const bytes = getU128Encoder().encode(42);
+ * const value = getU128Decoder().decode(bytes);
+ * ```
+ *
+ * @see {@link getU128Encoder}
+ * @see {@link getU128Decoder}
+ */
 export const getU128Codec = (config: NumberCodecConfig = {}): FixedSizeCodec<bigint | number, bigint, 16> =>
     combineCodec(getU128Encoder(config), getU128Decoder(config));

--- a/packages/codecs-numbers/src/u16.ts
+++ b/packages/codecs-numbers/src/u16.ts
@@ -3,6 +3,26 @@ import { combineCodec, FixedSizeCodec, FixedSizeDecoder, FixedSizeEncoder } from
 import { NumberCodecConfig } from './common';
 import { numberDecoderFactory, numberEncoderFactory } from './utils';
 
+/**
+ * Returns an encoder for 16-bit unsigned integers (`u16`).
+ *
+ * This encoder serializes `u16` values using two bytes in little-endian format by default.
+ * You may specify big-endian storage using the `endian` option.
+ *
+ * For more details, see {@link getU16Codec}.
+ *
+ * @param config - Optional settings for endianness.
+ * @returns A `FixedSizeEncoder<number | bigint, 2>` for encoding `u16` values.
+ *
+ * @example
+ * Encoding a `u16` value.
+ * ```ts
+ * const encoder = getU16Encoder();
+ * const bytes = encoder.encode(42); // 0x2a00
+ * ```
+ *
+ * @see {@link getU16Codec}
+ */
 export const getU16Encoder = (config: NumberCodecConfig = {}): FixedSizeEncoder<bigint | number, 2> =>
     numberEncoderFactory({
         config,
@@ -12,6 +32,26 @@ export const getU16Encoder = (config: NumberCodecConfig = {}): FixedSizeEncoder<
         size: 2,
     });
 
+/**
+ * Returns a decoder for 16-bit unsigned integers (`u16`).
+ *
+ * This decoder deserializes `u16` values from two bytes in little-endian format by default.
+ * You may specify big-endian storage using the `endian` option.
+ *
+ * For more details, see {@link getU16Codec}.
+ *
+ * @param config - Optional settings for endianness.
+ * @returns A `FixedSizeDecoder<number, 2>` for decoding `u16` values.
+ *
+ * @example
+ * Decoding a `u16` value.
+ * ```ts
+ * const decoder = getU16Decoder();
+ * const value = decoder.decode(new Uint8Array([0x2a, 0x00])); // 42
+ * ```
+ *
+ * @see {@link getU16Codec}
+ */
 export const getU16Decoder = (config: NumberCodecConfig = {}): FixedSizeDecoder<number, 2> =>
     numberDecoderFactory({
         config,
@@ -20,5 +60,44 @@ export const getU16Decoder = (config: NumberCodecConfig = {}): FixedSizeDecoder<
         size: 2,
     });
 
+/**
+ * Returns a codec for encoding and decoding 16-bit unsigned integers (`u16`).
+ *
+ * This codec serializes `u16` values using two bytes in little-endian format by default.
+ * You may specify big-endian storage using the `endian` option.
+ *
+ * @param config - Optional settings for endianness.
+ * @returns A `FixedSizeCodec<number | bigint, number, 2>` for encoding and decoding `u16` values.
+ *
+ * @example
+ * Encoding and decoding a `u16` value.
+ * ```ts
+ * const codec = getU16Codec();
+ * const bytes = codec.encode(42); // 0x2a00 (little-endian)
+ * const value = codec.decode(bytes); // 42
+ * ```
+ *
+ * @example
+ * Storing values in big-endian format.
+ * ```ts
+ * const codec = getU16Codec({ endian: Endian.Big });
+ * const bytes = codec.encode(42); // 0x002a
+ * ```
+ *
+ * @remarks
+ * This codec supports values between `0` and `2^16 - 1`.
+ * If you need a larger range, consider using {@link getU32Codec} or {@link getU64Codec}.
+ * For signed integers, use {@link getI16Codec}.
+ *
+ * Separate {@link getU16Encoder} and {@link getU16Decoder} functions are available.
+ *
+ * ```ts
+ * const bytes = getU16Encoder().encode(42);
+ * const value = getU16Decoder().decode(bytes);
+ * ```
+ *
+ * @see {@link getU16Encoder}
+ * @see {@link getU16Decoder}
+ */
 export const getU16Codec = (config: NumberCodecConfig = {}): FixedSizeCodec<bigint | number, number, 2> =>
     combineCodec(getU16Encoder(config), getU16Decoder(config));

--- a/packages/codecs-numbers/src/u32.ts
+++ b/packages/codecs-numbers/src/u32.ts
@@ -3,6 +3,26 @@ import { combineCodec, FixedSizeCodec, FixedSizeDecoder, FixedSizeEncoder } from
 import { NumberCodecConfig } from './common';
 import { numberDecoderFactory, numberEncoderFactory } from './utils';
 
+/**
+ * Returns an encoder for 32-bit unsigned integers (`u32`).
+ *
+ * This encoder serializes `u32` values using four bytes in little-endian format by default.
+ * You may specify big-endian storage using the `endian` option.
+ *
+ * For more details, see {@link getU32Codec}.
+ *
+ * @param config - Optional settings for endianness.
+ * @returns A `FixedSizeEncoder<bigint | number, 4>` for encoding `u32` values.
+ *
+ * @example
+ * Encoding a `u32` value.
+ * ```ts
+ * const encoder = getU32Encoder();
+ * const bytes = encoder.encode(42); // 0x2a000000
+ * ```
+ *
+ * @see {@link getU32Codec}
+ */
 export const getU32Encoder = (config: NumberCodecConfig = {}): FixedSizeEncoder<bigint | number, 4> =>
     numberEncoderFactory({
         config,
@@ -12,6 +32,26 @@ export const getU32Encoder = (config: NumberCodecConfig = {}): FixedSizeEncoder<
         size: 4,
     });
 
+/**
+ * Returns a decoder for 32-bit unsigned integers (`u32`).
+ *
+ * This decoder deserializes `u32` values from four bytes in little-endian format by default.
+ * You may specify big-endian storage using the `endian` option.
+ *
+ * For more details, see {@link getU32Codec}.
+ *
+ * @param config - Optional settings for endianness.
+ * @returns A `FixedSizeDecoder<number, 4>` for decoding `u32` values.
+ *
+ * @example
+ * Decoding a `u32` value.
+ * ```ts
+ * const decoder = getU32Decoder();
+ * const value = decoder.decode(new Uint8Array([0x2a, 0x00, 0x00, 0x00])); // 42
+ * ```
+ *
+ * @see {@link getU32Codec}
+ */
 export const getU32Decoder = (config: NumberCodecConfig = {}): FixedSizeDecoder<number, 4> =>
     numberDecoderFactory({
         config,
@@ -20,5 +60,44 @@ export const getU32Decoder = (config: NumberCodecConfig = {}): FixedSizeDecoder<
         size: 4,
     });
 
+/**
+ * Returns a codec for encoding and decoding 32-bit unsigned integers (`u32`).
+ *
+ * This codec serializes `u32` values using four bytes in little-endian format by default.
+ * You may specify big-endian storage using the `endian` option.
+ *
+ * @param config - Optional settings for endianness.
+ * @returns A `FixedSizeCodec<bigint | number, number, 4>` for encoding and decoding `u32` values.
+ *
+ * @example
+ * Encoding and decoding a `u32` value.
+ * ```ts
+ * const codec = getU32Codec();
+ * const bytes = codec.encode(42); // 0x2a000000 (little-endian)
+ * const value = codec.decode(bytes); // 42
+ * ```
+ *
+ * @example
+ * Storing values in big-endian format.
+ * ```ts
+ * const codec = getU32Codec({ endian: Endian.Big });
+ * const bytes = codec.encode(42); // 0x0000002a
+ * ```
+ *
+ * @remarks
+ * This codec only supports values between `0` and `2^32 - 1`.
+ * If you need a larger range, consider using {@link getU64Codec} or {@link getU128Codec}.
+ * For signed integers, use {@link getI32Codec}.
+ *
+ * Separate {@link getU32Encoder} and {@link getU32Decoder} functions are available.
+ *
+ * ```ts
+ * const bytes = getU32Encoder().encode(42);
+ * const value = getU32Decoder().decode(bytes);
+ * ```
+ *
+ * @see {@link getU32Encoder}
+ * @see {@link getU32Decoder}
+ */
 export const getU32Codec = (config: NumberCodecConfig = {}): FixedSizeCodec<bigint | number, number, 4> =>
     combineCodec(getU32Encoder(config), getU32Decoder(config));

--- a/packages/codecs-numbers/src/u64.ts
+++ b/packages/codecs-numbers/src/u64.ts
@@ -3,6 +3,26 @@ import { combineCodec, FixedSizeCodec, FixedSizeDecoder, FixedSizeEncoder } from
 import { NumberCodecConfig } from './common';
 import { numberDecoderFactory, numberEncoderFactory } from './utils';
 
+/**
+ * Returns an encoder for 64-bit unsigned integers (`u64`).
+ *
+ * This encoder serializes `u64` values using 8 bytes.
+ * Values can be provided as either `number` or `bigint`.
+ *
+ * For more details, see {@link getU64Codec}.
+ *
+ * @param config - Optional configuration to specify endianness (little by default).
+ * @returns A `FixedSizeEncoder<number | bigint, 8>` for encoding `u64` values.
+ *
+ * @example
+ * Encoding a `u64` value.
+ * ```ts
+ * const encoder = getU64Encoder();
+ * const bytes = encoder.encode(42); // 0x2a00000000000000
+ * ```
+ *
+ * @see {@link getU64Codec}
+ */
 export const getU64Encoder = (config: NumberCodecConfig = {}): FixedSizeEncoder<bigint | number, 8> =>
     numberEncoderFactory({
         config,
@@ -12,6 +32,26 @@ export const getU64Encoder = (config: NumberCodecConfig = {}): FixedSizeEncoder<
         size: 8,
     });
 
+/**
+ * Returns a decoder for 64-bit unsigned integers (`u64`).
+ *
+ * This decoder deserializes `u64` values from 8 bytes.
+ * The decoded value is always a `bigint`.
+ *
+ * For more details, see {@link getU64Codec}.
+ *
+ * @param config - Optional configuration to specify endianness (little by default).
+ * @returns A `FixedSizeDecoder<bigint, 8>` for decoding `u64` values.
+ *
+ * @example
+ * Decoding a `u64` value.
+ * ```ts
+ * const decoder = getU64Decoder();
+ * const value = decoder.decode(new Uint8Array([0x2a, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00])); // 42n
+ * ```
+ *
+ * @see {@link getU64Codec}
+ */
 export const getU64Decoder = (config: NumberCodecConfig = {}): FixedSizeDecoder<bigint, 8> =>
     numberDecoderFactory({
         config,
@@ -20,5 +60,47 @@ export const getU64Decoder = (config: NumberCodecConfig = {}): FixedSizeDecoder<
         size: 8,
     });
 
+/**
+ * Returns a codec for encoding and decoding 64-bit unsigned integers (`u64`).
+ *
+ * This codec serializes `u64` values using 8 bytes.
+ * Values can be provided as either `number` or `bigint`, but the decoded value is always a `bigint`.
+ *
+ * @param config - Optional configuration to specify endianness (little by default).
+ * @returns A `FixedSizeCodec<number | bigint, bigint, 8>` for encoding and decoding `u64` values.
+ *
+ * @example
+ * Encoding and decoding a `u64` value.
+ * ```ts
+ * const codec = getU64Codec();
+ * const bytes = codec.encode(42); // 0x2a00000000000000
+ * const value = codec.decode(bytes); // 42n
+ * ```
+ *
+ * @example
+ * Using big-endian encoding.
+ * ```ts
+ * const codec = getU64Codec({ endian: Endian.Big });
+ * const bytes = codec.encode(42); // 0x000000000000002a
+ * ```
+ *
+ * @remarks
+ * This codec supports values between `0` and `2^64 - 1`.
+ * Since JavaScript `number` cannot safely represent values beyond `2^53 - 1`, the decoded value is always a `bigint`.
+ *
+ * - If you need a smaller unsigned integer, consider using {@link getU32Codec} or {@link getU16Codec}.
+ * - If you need a larger unsigned integer, consider using {@link getU128Codec}.
+ * - If you need signed integers, consider using {@link getI64Codec}.
+ *
+ * Separate {@link getU64Encoder} and {@link getU64Decoder} functions are available.
+ *
+ * ```ts
+ * const bytes = getU64Encoder().encode(42);
+ * const value = getU64Decoder().decode(bytes);
+ * ```
+ *
+ * @see {@link getU64Encoder}
+ * @see {@link getU64Decoder}
+ */
 export const getU64Codec = (config: NumberCodecConfig = {}): FixedSizeCodec<bigint | number, bigint, 8> =>
     combineCodec(getU64Encoder(config), getU64Decoder(config));

--- a/packages/codecs-numbers/src/u8.ts
+++ b/packages/codecs-numbers/src/u8.ts
@@ -2,6 +2,24 @@ import { combineCodec, FixedSizeCodec, FixedSizeDecoder, FixedSizeEncoder } from
 
 import { numberDecoderFactory, numberEncoderFactory } from './utils';
 
+/**
+ * Returns an encoder for 8-bit unsigned integers (`u8`).
+ *
+ * This encoder serializes `u8` values using a single byte.
+ *
+ * For more details, see {@link getU8Codec}.
+ *
+ * @returns A `FixedSizeEncoder<number | bigint, 1>` for encoding `u8` values.
+ *
+ * @example
+ * Encoding a `u8` value.
+ * ```ts
+ * const encoder = getU8Encoder();
+ * const bytes = encoder.encode(42); // 0x2a
+ * ```
+ *
+ * @see {@link getU8Codec}
+ */
 export const getU8Encoder = (): FixedSizeEncoder<bigint | number, 1> =>
     numberEncoderFactory({
         name: 'u8',
@@ -10,6 +28,24 @@ export const getU8Encoder = (): FixedSizeEncoder<bigint | number, 1> =>
         size: 1,
     });
 
+/**
+ * Returns a decoder for 8-bit unsigned integers (`u8`).
+ *
+ * This decoder deserializes `u8` values from a single byte.
+ *
+ * For more details, see {@link getU8Codec}.
+ *
+ * @returns A `FixedSizeDecoder<number, 1>` for decoding `u8` values.
+ *
+ * @example
+ * Decoding a `u8` value.
+ * ```ts
+ * const decoder = getU8Decoder();
+ * const value = decoder.decode(new Uint8Array([0xff])); // 255
+ * ```
+ *
+ * @see {@link getU8Codec}
+ */
 export const getU8Decoder = (): FixedSizeDecoder<number, 1> =>
     numberDecoderFactory({
         get: view => view.getUint8(0),
@@ -17,5 +53,35 @@ export const getU8Decoder = (): FixedSizeDecoder<number, 1> =>
         size: 1,
     });
 
+/**
+ * Returns a codec for encoding and decoding 8-bit unsigned integers (`u8`).
+ *
+ * This codec serializes `u8` values using a single byte.
+ *
+ * @returns A `FixedSizeCodec<number | bigint, number, 1>` for encoding and decoding `u8` values.
+ *
+ * @example
+ * Encoding and decoding a `u8` value.
+ * ```ts
+ * const codec = getU8Codec();
+ * const bytes = codec.encode(255); // 0xff
+ * const value = codec.decode(bytes); // 255
+ * ```
+ *
+ * @remarks
+ * This codec supports values between `0` and `2^8 - 1` (0 to 255).
+ * If you need larger integers, consider using {@link getU16Codec}, {@link getU32Codec}, or {@link getU64Codec}.
+ * For signed integers, use {@link getI8Codec}.
+ *
+ * Separate {@link getU8Encoder} and {@link getU8Decoder} functions are available.
+ *
+ * ```ts
+ * const bytes = getU8Encoder().encode(42);
+ * const value = getU8Decoder().decode(bytes);
+ * ```
+ *
+ * @see {@link getU8Encoder}
+ * @see {@link getU8Decoder}
+ */
 export const getU8Codec = (): FixedSizeCodec<bigint | number, number, 1> =>
     combineCodec(getU8Encoder(), getU8Decoder());

--- a/packages/codecs-numbers/typedoc.json
+++ b/packages/codecs-numbers/typedoc.json
@@ -1,5 +1,6 @@
 {
     "$schema": "https://typedoc.org/schema.json",
     "extends": ["../typedoc.base.json"],
-    "entryPoints": ["src/index.ts"]
+    "entryPoints": ["src/index.ts"],
+    "readme": "none"
 }

--- a/packages/codecs-strings/src/assertions.ts
+++ b/packages/codecs-strings/src/assertions.ts
@@ -1,7 +1,24 @@
 import { SOLANA_ERROR__CODECS__INVALID_STRING_FOR_BASE, SolanaError } from '@solana/errors';
 
 /**
- * Asserts that a given string matches a given alphabet.
+ * Asserts that a given string contains only characters from the specified alphabet.
+ *
+ * This function validates whether a string consists exclusively of characters
+ * from the provided `alphabet`. If the validation fails, it throws an error
+ * indicating the invalid base string.
+ *
+ * @param alphabet - The allowed set of characters for the base encoding.
+ * @param testValue - The string to validate against the given alphabet.
+ * @param givenValue - The original string provided by the user (defaults to `testValue`).
+ *
+ * @throws {SolanaError} If `testValue` contains characters not present in `alphabet`.
+ *
+ * @example
+ * Validating a base-8 encoded string.
+ * ```ts
+ * assertValidBaseString('01234567', '123047'); // Passes
+ * assertValidBaseString('01234567', '128');    // Throws error
+ * ```
  */
 export function assertValidBaseString(alphabet: string, testValue: string, givenValue = testValue) {
     if (!testValue.match(new RegExp(`^[${alphabet}]*$`))) {

--- a/packages/codecs-strings/src/base10.ts
+++ b/packages/codecs-strings/src/base10.ts
@@ -2,11 +2,86 @@ import { getBaseXCodec, getBaseXDecoder, getBaseXEncoder } from './baseX';
 
 const alphabet = '0123456789';
 
-/** Encodes strings in base10. */
+/**
+ * Returns an encoder for base-10 strings.
+ *
+ * This encoder serializes strings using a base-10 encoding scheme.
+ * The output consists of bytes representing the numerical values of the input string.
+ *
+ * For more details, see {@link getBase10Codec}.
+ *
+ * @returns A `VariableSizeEncoder<string>` for encoding base-10 strings.
+ *
+ * @example
+ * Encoding a base-10 string.
+ * ```ts
+ * const encoder = getBase10Encoder();
+ * const bytes = encoder.encode('1024'); // 0x0400
+ * ```
+ *
+ * @see {@link getBase10Codec}
+ */
 export const getBase10Encoder = () => getBaseXEncoder(alphabet);
 
-/** Decodes strings in base10. */
+/**
+ * Returns a decoder for base-10 strings.
+ *
+ * This decoder deserializes base-10 encoded strings from a byte array.
+ *
+ * For more details, see {@link getBase10Codec}.
+ *
+ * @returns A `VariableSizeDecoder<string>` for decoding base-10 strings.
+ *
+ * @example
+ * Decoding a base-10 string.
+ * ```ts
+ * const decoder = getBase10Decoder();
+ * const value = decoder.decode(new Uint8Array([0x04, 0x00])); // "1024"
+ * ```
+ *
+ * @see {@link getBase10Codec}
+ */
 export const getBase10Decoder = () => getBaseXDecoder(alphabet);
 
-/** Encodes and decodes strings in base10. */
+/**
+ * Returns a codec for encoding and decoding base-10 strings.
+ *
+ * This codec serializes strings using a base-10 encoding scheme.
+ * The output consists of bytes representing the numerical values of the input string.
+ *
+ * @returns A `VariableSizeCodec<string>` for encoding and decoding base-10 strings.
+ *
+ * @example
+ * Encoding and decoding a base-10 string.
+ * ```ts
+ * const codec = getBase10Codec();
+ * const bytes = codec.encode('1024'); // 0x0400
+ * const value = codec.decode(bytes);  // "1024"
+ * ```
+ *
+ * @remarks
+ * This codec does not enforce a size boundary. It will encode and decode all bytes necessary to represent the string.
+ *
+ * If you need a fixed-size base-10 codec, consider using {@link fixCodecSize}.
+ *
+ * ```ts
+ * const codec = fixCodecSize(getBase10Codec(), 5);
+ * ```
+ *
+ * If you need a size-prefixed base-10 codec, consider using {@link addCodecSizePrefix}.
+ *
+ * ```ts
+ * const codec = addCodecSizePrefix(getBase10Codec(), getU32Codec());
+ * ```
+ *
+ * Separate {@link getBase10Encoder} and {@link getBase10Decoder} functions are available.
+ *
+ * ```ts
+ * const bytes = getBase10Encoder().encode('1024');
+ * const value = getBase10Decoder().decode(bytes);
+ * ```
+ *
+ * @see {@link getBase10Encoder}
+ * @see {@link getBase10Decoder}
+ */
 export const getBase10Codec = () => getBaseXCodec(alphabet);

--- a/packages/codecs-strings/src/base16.ts
+++ b/packages/codecs-strings/src/base16.ts
@@ -28,7 +28,25 @@ function charCodeToBase16(char: number) {
     if (char >= HexC.A_LO && char <= HexC.F_LO) return char - (HexC.A_LO - 10);
 }
 
-/** Encodes strings in base16. */
+/**
+ * Returns an encoder for base-16 (hexadecimal) strings.
+ *
+ * This encoder serializes strings using a base-16 encoding scheme.
+ * The output consists of bytes representing the hexadecimal values of the input string.
+ *
+ * For more details, see {@link getBase16Codec}.
+ *
+ * @returns A `VariableSizeEncoder<string>` for encoding base-16 strings.
+ *
+ * @example
+ * Encoding a base-16 string.
+ * ```ts
+ * const encoder = getBase16Encoder();
+ * const bytes = encoder.encode('deadface'); // 0xdeadface
+ * ```
+ *
+ * @see {@link getBase16Codec}
+ */
 export const getBase16Encoder = (): VariableSizeEncoder<string> =>
     createEncoder({
         getSizeFromValue: (value: string) => Math.ceil(value.length / 2),
@@ -68,7 +86,24 @@ export const getBase16Encoder = (): VariableSizeEncoder<string> =>
         },
     });
 
-/** Decodes strings in base16. */
+/**
+ * Returns a decoder for base-16 (hexadecimal) strings.
+ *
+ * This decoder deserializes base-16 encoded strings from a byte array.
+ *
+ * For more details, see {@link getBase16Codec}.
+ *
+ * @returns A `VariableSizeDecoder<string>` for decoding base-16 strings.
+ *
+ * @example
+ * Decoding a base-16 string.
+ * ```ts
+ * const decoder = getBase16Decoder();
+ * const value = decoder.decode(new Uint8Array([0xde, 0xad, 0xfa, 0xce])); // "deadface"
+ * ```
+ *
+ * @see {@link getBase16Codec}
+ */
 export const getBase16Decoder = (): VariableSizeDecoder<string> =>
     createDecoder({
         read(bytes, offset) {
@@ -77,5 +112,45 @@ export const getBase16Decoder = (): VariableSizeDecoder<string> =>
         },
     });
 
-/** Encodes and decodes strings in base16. */
+/**
+ * Returns a codec for encoding and decoding base-16 (hexadecimal) strings.
+ *
+ * This codec serializes strings using a base-16 encoding scheme.
+ * The output consists of bytes representing the hexadecimal values of the input string.
+ *
+ * @returns A `VariableSizeCodec<string>` for encoding and decoding base-16 strings.
+ *
+ * @example
+ * Encoding and decoding a base-16 string.
+ * ```ts
+ * const codec = getBase16Codec();
+ * const bytes = codec.encode('deadface'); // 0xdeadface
+ * const value = codec.decode(bytes);      // "deadface"
+ * ```
+ *
+ * @remarks
+ * This codec does not enforce a size boundary. It will encode and decode all bytes necessary to represent the string.
+ *
+ * If you need a fixed-size base-16 codec, consider using {@link fixCodecSize}.
+ *
+ * ```ts
+ * const codec = fixCodecSize(getBase16Codec(), 8);
+ * ```
+ *
+ * If you need a size-prefixed base-16 codec, consider using {@link addCodecSizePrefix}.
+ *
+ * ```ts
+ * const codec = addCodecSizePrefix(getBase16Codec(), getU32Codec());
+ * ```
+ *
+ * Separate {@link getBase16Encoder} and {@link getBase16Decoder} functions are available.
+ *
+ * ```ts
+ * const bytes = getBase16Encoder().encode('deadface');
+ * const value = getBase16Decoder().decode(bytes);
+ * ```
+ *
+ * @see {@link getBase16Encoder}
+ * @see {@link getBase16Decoder}
+ */
 export const getBase16Codec = (): VariableSizeCodec<string> => combineCodec(getBase16Encoder(), getBase16Decoder());

--- a/packages/codecs-strings/src/base58.ts
+++ b/packages/codecs-strings/src/base58.ts
@@ -2,11 +2,86 @@ import { getBaseXCodec, getBaseXDecoder, getBaseXEncoder } from './baseX';
 
 const alphabet = '123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz';
 
-/** Encodes strings in base58. */
+/**
+ * Returns an encoder for base-58 strings.
+ *
+ * This encoder serializes strings using a base-58 encoding scheme,
+ * commonly used in cryptocurrency addresses and other compact representations.
+ *
+ * For more details, see {@link getBase58Codec}.
+ *
+ * @returns A `VariableSizeEncoder<string>` for encoding base-58 strings.
+ *
+ * @example
+ * Encoding a base-58 string.
+ * ```ts
+ * const encoder = getBase58Encoder();
+ * const bytes = encoder.encode('heLLo'); // 0x1b6a3070
+ * ```
+ *
+ * @see {@link getBase58Codec}
+ */
 export const getBase58Encoder = () => getBaseXEncoder(alphabet);
 
-/** Decodes strings in base58. */
+/**
+ * Returns a decoder for base-58 strings.
+ *
+ * This decoder deserializes base-58 encoded strings from a byte array.
+ *
+ * For more details, see {@link getBase58Codec}.
+ *
+ * @returns A `VariableSizeDecoder<string>` for decoding base-58 strings.
+ *
+ * @example
+ * Decoding a base-58 string.
+ * ```ts
+ * const decoder = getBase58Decoder();
+ * const value = decoder.decode(new Uint8Array([0x1b, 0x6a, 0x30, 0x70])); // "heLLo"
+ * ```
+ *
+ * @see {@link getBase58Codec}
+ */
 export const getBase58Decoder = () => getBaseXDecoder(alphabet);
 
-/** Encodes and decodes strings in base58. */
+/**
+ * Returns a codec for encoding and decoding base-58 strings.
+ *
+ * This codec serializes strings using a base-58 encoding scheme,
+ * commonly used in cryptocurrency addresses and other compact representations.
+ *
+ * @returns A `VariableSizeCodec<string>` for encoding and decoding base-58 strings.
+ *
+ * @example
+ * Encoding and decoding a base-58 string.
+ * ```ts
+ * const codec = getBase58Codec();
+ * const bytes = codec.encode('heLLo'); // 0x1b6a3070
+ * const value = codec.decode(bytes);   // "heLLo"
+ * ```
+ *
+ * @remarks
+ * This codec does not enforce a size boundary. It will encode and decode all bytes necessary to represent the string.
+ *
+ * If you need a fixed-size base-58 codec, consider using {@link fixCodecSize}.
+ *
+ * ```ts
+ * const codec = fixCodecSize(getBase58Codec(), 8);
+ * ```
+ *
+ * If you need a size-prefixed base-58 codec, consider using {@link addCodecSizePrefix}.
+ *
+ * ```ts
+ * const codec = addCodecSizePrefix(getBase58Codec(), getU32Codec());
+ * ```
+ *
+ * Separate {@link getBase58Encoder} and {@link getBase58Decoder} functions are available.
+ *
+ * ```ts
+ * const bytes = getBase58Encoder().encode('heLLo');
+ * const value = getBase58Decoder().decode(bytes);
+ * ```
+ *
+ * @see {@link getBase58Encoder}
+ * @see {@link getBase58Decoder}
+ */
 export const getBase58Codec = () => getBaseXCodec(alphabet);

--- a/packages/codecs-strings/src/base64.ts
+++ b/packages/codecs-strings/src/base64.ts
@@ -15,7 +15,25 @@ import { getBaseXResliceDecoder, getBaseXResliceEncoder } from './baseX-reslice'
 
 const alphabet = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/';
 
-/** Encodes strings in base64. */
+/**
+ * Returns an encoder for base-64 strings.
+ *
+ * This encoder serializes strings using a base-64 encoding scheme,
+ * commonly used for data encoding in URLs, cryptographic keys, and binary-to-text encoding.
+ *
+ * For more details, see {@link getBase64Codec}.
+ *
+ * @returns A `VariableSizeEncoder<string>` for encoding base-64 strings.
+ *
+ * @example
+ * Encoding a base-64 string.
+ * ```ts
+ * const encoder = getBase64Encoder();
+ * const bytes = encoder.encode('hello+world'); // 0x85e965a3ec28ae57
+ * ```
+ *
+ * @see {@link getBase64Codec}
+ */
 export const getBase64Encoder = (): VariableSizeEncoder<string> => {
     if (__BROWSER__) {
         return createEncoder({
@@ -63,7 +81,24 @@ export const getBase64Encoder = (): VariableSizeEncoder<string> => {
     return transformEncoder(getBaseXResliceEncoder(alphabet, 6), (value: string): string => value.replace(/=/g, ''));
 };
 
-/** Decodes strings in base64. */
+/**
+ * Returns a decoder for base-64 strings.
+ *
+ * This decoder deserializes base-64 encoded strings from a byte array.
+ *
+ * For more details, see {@link getBase64Codec}.
+ *
+ * @returns A `VariableSizeDecoder<string>` for decoding base-64 strings.
+ *
+ * @example
+ * Decoding a base-64 string.
+ * ```ts
+ * const decoder = getBase64Decoder();
+ * const value = decoder.decode(new Uint8Array([0x85, 0xe9, 0x65, 0xa3, 0xec, 0x28, 0xae, 0x57])); // "hello+world"
+ * ```
+ *
+ * @see {@link getBase64Codec}
+ */
 export const getBase64Decoder = (): VariableSizeDecoder<string> => {
     if (__BROWSER__) {
         return createDecoder({
@@ -86,5 +121,45 @@ export const getBase64Decoder = (): VariableSizeDecoder<string> => {
     );
 };
 
-/** Encodes and decodes strings in base64. */
+/**
+ * Returns a codec for encoding and decoding base-64 strings.
+ *
+ * This codec serializes strings using a base-64 encoding scheme,
+ * commonly used for data encoding in URLs, cryptographic keys, and binary-to-text encoding.
+ *
+ * @returns A `VariableSizeCodec<string>` for encoding and decoding base-64 strings.
+ *
+ * @example
+ * Encoding and decoding a base-64 string.
+ * ```ts
+ * const codec = getBase64Codec();
+ * const bytes = codec.encode('hello+world'); // 0x85e965a3ec28ae57
+ * const value = codec.decode(bytes);         // "hello+world"
+ * ```
+ *
+ * @remarks
+ * This codec does not enforce a size boundary. It will encode and decode all bytes necessary to represent the string.
+ *
+ * If you need a fixed-size base-64 codec, consider using {@link fixCodecSize}.
+ *
+ * ```ts
+ * const codec = fixCodecSize(getBase64Codec(), 8);
+ * ```
+ *
+ * If you need a size-prefixed base-64 codec, consider using {@link addCodecSizePrefix}.
+ *
+ * ```ts
+ * const codec = addCodecSizePrefix(getBase64Codec(), getU32Codec());
+ * ```
+ *
+ * Separate {@link getBase64Encoder} and {@link getBase64Decoder} functions are available.
+ *
+ * ```ts
+ * const bytes = getBase64Encoder().encode('hello+world');
+ * const value = getBase64Decoder().decode(bytes);
+ * ```
+ *
+ * @see {@link getBase64Encoder}
+ * @see {@link getBase64Decoder}
+ */
 export const getBase64Codec = (): VariableSizeCodec<string> => combineCodec(getBase64Encoder(), getBase64Decoder());

--- a/packages/codecs-strings/src/baseX-reslice.ts
+++ b/packages/codecs-strings/src/baseX-reslice.ts
@@ -10,8 +10,27 @@ import {
 import { assertValidBaseString } from './assertions';
 
 /**
- * Encodes a string using a custom alphabet by reslicing the bits of the byte array.
- * @see {@link getBaseXResliceCodec} for a more detailed description.
+ * Returns an encoder for base-X encoded strings using bit re-slicing.
+ *
+ * This encoder serializes strings by dividing the input into custom-sized bit chunks,
+ * mapping them to an alphabet, and encoding the result into a byte array.
+ * This approach is commonly used for encoding schemes where the alphabet's length is a power of 2,
+ * such as base-16 or base-64.
+ *
+ * For more details, see {@link getBaseXResliceCodec}.
+ *
+ * @param alphabet - The set of characters defining the base-X encoding.
+ * @param bits - The number of bits per encoded chunk, typically `log2(alphabet.length)`.
+ * @returns A `VariableSizeEncoder<string>` for encoding base-X strings using bit re-slicing.
+ *
+ * @example
+ * Encoding a base-X string using bit re-slicing.
+ * ```ts
+ * const encoder = getBaseXResliceEncoder('elho', 2);
+ * const bytes = encoder.encode('hellolol'); // 0x4aee
+ * ```
+ *
+ * @see {@link getBaseXResliceCodec}
  */
 export const getBaseXResliceEncoder = (alphabet: string, bits: number): VariableSizeEncoder<string> =>
     createEncoder({
@@ -27,8 +46,27 @@ export const getBaseXResliceEncoder = (alphabet: string, bits: number): Variable
     });
 
 /**
- * Decodes a string using a custom alphabet by reslicing the bits of the byte array.
- * @see {@link getBaseXResliceCodec} for a more detailed description.
+ * Returns a decoder for base-X encoded strings using bit re-slicing.
+ *
+ * This decoder deserializes base-X encoded strings by re-slicing the bits of a byte array into
+ * custom-sized chunks and mapping them to a specified alphabet.
+ * This is typically used for encoding schemes where the alphabet's length is a power of 2,
+ * such as base-16 or base-64.
+ *
+ * For more details, see {@link getBaseXResliceCodec}.
+ *
+ * @param alphabet - The set of characters defining the base-X encoding.
+ * @param bits - The number of bits per encoded chunk, typically `log2(alphabet.length)`.
+ * @returns A `VariableSizeDecoder<string>` for decoding base-X strings using bit re-slicing.
+ *
+ * @example
+ * Decoding a base-X string using bit re-slicing.
+ * ```ts
+ * const decoder = getBaseXResliceDecoder('elho', 2);
+ * const value = decoder.decode(new Uint8Array([0x4a, 0xee])); // "hellolol"
+ * ```
+ *
+ * @see {@link getBaseXResliceCodec}
  */
 export const getBaseXResliceDecoder = (alphabet: string, bits: number): VariableSizeDecoder<string> =>
     createDecoder({
@@ -41,11 +79,49 @@ export const getBaseXResliceDecoder = (alphabet: string, bits: number): Variable
     });
 
 /**
- * A string serializer that reslices bytes into custom chunks
- * of bits that are then mapped to a custom alphabet.
+ * Returns a codec for encoding and decoding base-X strings using bit re-slicing.
  *
- * This can be used to create serializers whose alphabet
- * is a power of 2 such as base16 or base64.
+ * This codec serializes strings by dividing the input into custom-sized bit chunks,
+ * mapping them to a given alphabet, and encoding the result into bytes.
+ * It is particularly suited for encoding schemes where the alphabet's length is a power of 2,
+ * such as base-16 or base-64.
+ *
+ * @param alphabet - The set of characters defining the base-X encoding.
+ * @param bits - The number of bits per encoded chunk, typically `log2(alphabet.length)`.
+ * @returns A `VariableSizeCodec<string>` for encoding and decoding base-X strings using bit re-slicing.
+ *
+ * @example
+ * Encoding and decoding a base-X string using bit re-slicing.
+ * ```ts
+ * const codec = getBaseXResliceCodec('elho', 2);
+ * const bytes = codec.encode('hellolol'); // 0x4aee
+ * const value = codec.decode(bytes);      // "hellolol"
+ * ```
+ *
+ * @remarks
+ * This codec does not enforce a size boundary. It will encode and decode all bytes necessary to represent the string.
+ *
+ * If you need a fixed-size base-X codec, consider using {@link fixCodecSize}.
+ *
+ * ```ts
+ * const codec = fixCodecSize(getBaseXResliceCodec('elho', 2), 8);
+ * ```
+ *
+ * If you need a size-prefixed base-X codec, consider using {@link addCodecSizePrefix}.
+ *
+ * ```ts
+ * const codec = addCodecSizePrefix(getBaseXResliceCodec('elho', 2), getU32Codec());
+ * ```
+ *
+ * Separate {@link getBaseXResliceEncoder} and {@link getBaseXResliceDecoder} functions are available.
+ *
+ * ```ts
+ * const bytes = getBaseXResliceEncoder('elho', 2).encode('hellolol');
+ * const value = getBaseXResliceDecoder('elho', 2).decode(bytes);
+ * ```
+ *
+ * @see {@link getBaseXResliceEncoder}
+ * @see {@link getBaseXResliceDecoder}
  */
 export const getBaseXResliceCodec = (alphabet: string, bits: number): VariableSizeCodec<string> =>
     combineCodec(getBaseXResliceEncoder(alphabet, bits), getBaseXResliceDecoder(alphabet, bits));

--- a/packages/codecs-strings/src/baseX.ts
+++ b/packages/codecs-strings/src/baseX.ts
@@ -10,9 +10,25 @@ import {
 import { assertValidBaseString } from './assertions';
 
 /**
- * Encodes a string using a custom alphabet by dividing
- * by the base and handling leading zeroes.
- * @see {@link getBaseXCodec} for a more detailed description.
+ * Returns an encoder for base-X encoded strings.
+ *
+ * This encoder serializes strings using a custom alphabet, treating the length of the alphabet as the base.
+ * The encoding process involves converting the input string to a numeric value in base-X, then
+ * encoding that value into bytes while preserving leading zeroes.
+ *
+ * For more details, see {@link getBaseXCodec}.
+ *
+ * @param alphabet - The set of characters defining the base-X encoding.
+ * @returns A `VariableSizeEncoder<string>` for encoding base-X strings.
+ *
+ * @example
+ * Encoding a base-X string using a custom alphabet.
+ * ```ts
+ * const encoder = getBaseXEncoder('0123456789abcdef');
+ * const bytes = encoder.encode('deadface'); // 0xdeadface
+ * ```
+ *
+ * @see {@link getBaseXCodec}
  */
 export const getBaseXEncoder = (alphabet: string): VariableSizeEncoder<string> => {
     return createEncoder({
@@ -53,9 +69,25 @@ export const getBaseXEncoder = (alphabet: string): VariableSizeEncoder<string> =
 };
 
 /**
- * Decodes a string using a custom alphabet by dividing
- * by the base and handling leading zeroes.
- * @see {@link getBaseXCodec} for a more detailed description.
+ * Returns a decoder for base-X encoded strings.
+ *
+ * This decoder deserializes base-X encoded strings from a byte array using a custom alphabet.
+ * The decoding process converts the byte array into a numeric value in base-10, then
+ * maps that value back to characters in the specified base-X alphabet.
+ *
+ * For more details, see {@link getBaseXCodec}.
+ *
+ * @param alphabet - The set of characters defining the base-X encoding.
+ * @returns A `VariableSizeDecoder<string>` for decoding base-X strings.
+ *
+ * @example
+ * Decoding a base-X string using a custom alphabet.
+ * ```ts
+ * const decoder = getBaseXDecoder('0123456789abcdef');
+ * const value = decoder.decode(new Uint8Array([0xde, 0xad, 0xfa, 0xce])); // "deadface"
+ * ```
+ *
+ * @see {@link getBaseXCodec}
  */
 export const getBaseXDecoder = (alphabet: string): VariableSizeDecoder<string> => {
     return createDecoder({
@@ -81,13 +113,49 @@ export const getBaseXDecoder = (alphabet: string): VariableSizeDecoder<string> =
 };
 
 /**
- * A string codec that requires a custom alphabet and uses
- * the length of that alphabet as the base. It then divides
- * the input by the base as many times as necessary to get
- * the output. It also supports leading zeroes by using the
- * first character of the alphabet as the zero character.
+ * Returns a codec for encoding and decoding base-X strings.
  *
- * This can be used to create codecs such as base10 or base58.
+ * This codec serializes strings using a custom alphabet, treating the length of the alphabet as the base.
+ * The encoding process converts the input string into a numeric value in base-X, which is then encoded as bytes.
+ * The decoding process reverses this transformation to reconstruct the original string.
+ *
+ * This codec supports leading zeroes by treating the first character of the alphabet as the zero character.
+ *
+ * @param alphabet - The set of characters defining the base-X encoding.
+ * @returns A `VariableSizeCodec<string>` for encoding and decoding base-X strings.
+ *
+ * @example
+ * Encoding and decoding a base-X string using a custom alphabet.
+ * ```ts
+ * const codec = getBaseXCodec('0123456789abcdef');
+ * const bytes = codec.encode('deadface'); // 0xdeadface
+ * const value = codec.decode(bytes);      // "deadface"
+ * ```
+ *
+ * @remarks
+ * This codec does not enforce a size boundary. It will encode and decode all bytes necessary to represent the string.
+ *
+ * If you need a fixed-size base-X codec, consider using {@link fixCodecSize}.
+ *
+ * ```ts
+ * const codec = fixCodecSize(getBaseXCodec('0123456789abcdef'), 8);
+ * ```
+ *
+ * If you need a size-prefixed base-X codec, consider using {@link addCodecSizePrefix}.
+ *
+ * ```ts
+ * const codec = addCodecSizePrefix(getBaseXCodec('0123456789abcdef'), getU32Codec());
+ * ```
+ *
+ * Separate {@link getBaseXEncoder} and {@link getBaseXDecoder} functions are available.
+ *
+ * ```ts
+ * const bytes = getBaseXEncoder('0123456789abcdef').encode('deadface');
+ * const value = getBaseXDecoder('0123456789abcdef').decode(bytes);
+ * ```
+ *
+ * @see {@link getBaseXEncoder}
+ * @see {@link getBaseXDecoder}
  */
 export const getBaseXCodec = (alphabet: string): VariableSizeCodec<string> =>
     combineCodec(getBaseXEncoder(alphabet), getBaseXDecoder(alphabet));

--- a/packages/codecs-strings/src/index.ts
+++ b/packages/codecs-strings/src/index.ts
@@ -1,3 +1,204 @@
+/**
+ * This package contains codecs for strings of different sizes and encodings.
+ * It can be used standalone, but it is also exported as part of the Solana JavaScript SDK
+ * [`@solana/web3.js@next`](https://github.com/anza-xyz/solana-web3.js/tree/main/packages/library).
+ *
+ * This package is also part of the [`@solana/codecs` package](https://github.com/anza-xyz/solana-web3.js/tree/main/packages/codecs)
+ * which acts as an entry point for all codec packages as well as for their documentation.
+ *
+ * ## Sizing string codecs
+ *
+ * The `@solana/codecs-strings` package offers a variety of string codecs such as `utf8`, `base58`, `base64`, etc —
+ * which we will discuss in more detail below. However, before digging into the available string codecs,
+ * it's important to understand the different sizing strategies available for string codecs.
+ *
+ * By default, all available string codecs will return a `VariableSizeCodec<string>` meaning that:
+ *
+ * - When encoding a string, all bytes necessary to encode the string will be used.
+ * - When decoding a byte array at a given offset, all bytes starting from that offset will be decoded as a string.
+ *
+ * For instance, here's how you can encode/decode `utf8` strings without any size boundary:
+ *
+ * ```ts
+ * const codec = getUtf8Codec();
+ *
+ * codec.encode('hello');
+ * // 0x68656c6c6f
+ * //   └-- Any bytes necessary to encode our content.
+ *
+ * codec.decode(new Uint8Array([0x68, 0x65, 0x6c, 0x6c, 0x6f]));
+ * // 'hello'
+ * ```
+ *
+ * This might be what you want — e.g. when having a string at the end of a data structure — but in many cases,
+ * you might want to have a size boundary for your string. You may achieve this by composing your string codec
+ * with the [`fixCodecSize`](https://github.com/anza-xyz/solana-web3.js/tree/main/packages/codecs-core#fixing-the-size-of-codecs)
+ * or [`addCodecSizePrefix`](https://github.com/anza-xyz/solana-web3.js/tree/main/packages/codecs-core#prefixing-the-size-of-codecs) functions.
+ *
+ * The `fixCodecSize` function accepts a fixed byte length and returns a `FixedSizeCodec<string>` that will always use
+ * that amount of bytes to encode and decode a string. Any string longer or smaller than that size will be truncated
+ * or padded respectively. Here's how you can use it with a `utf8` codec:
+ *
+ * ```ts
+ * const codec = fixCodecSize(getUtf8Codec(), 5);
+ *
+ * codec.encode('hello');
+ * // 0x68656c6c6f
+ * //   └-- The exact 5 bytes of content.
+ *
+ * codec.encode('hello world');
+ * // 0x68656c6c6f
+ * //   └-- The truncated 5 bytes of content.
+ *
+ * codec.encode('hell');
+ * // 0x68656c6c00
+ * //   └-- The padded 5 bytes of content.
+ *
+ * codec.decode(new Uint8Array([0x68, 0x65, 0x6c, 0x6c, 0x6f, 0xff, 0xff, 0xff, 0xff]));
+ * // 'hello'
+ * ```
+ *
+ * The `addCodecSizePrefix` function accepts an additional number codec that will be used to encode and
+ * decode a size prefix for the string. This prefix allows us to know when to stop reading the string when
+ * decoding a given byte array. Here's how you can use it with a `utf8` codec:
+ *
+ * ```ts
+ * const codec = addCodecSizePrefix(getUtf8Codec(), getU32Codec());
+ *
+ * codec.encode('hello');
+ * // 0x0500000068656c6c6f
+ * //   |       └-- The 5 bytes of content.
+ * //   └-- 4-byte prefix telling us to read 5 bytes.
+ *
+ * codec.decode(new Uint8Array([0x05, 0x00, 0x00, 0x00, 0x68, 0x65, 0x6c, 0x6c, 0x6f, 0xff, 0xff, 0xff, 0xff]));
+ * // "hello"
+ * ```
+ *
+ * Now, let's take a look at the available string encodings. Just remember that you can use
+ * the `fixSizeCodec` or `prefixSizeCodec` functions on any of these encodings to add a size boundary to them.
+ *
+ * ## Utf8 codec
+ *
+ * The `getUtf8Codec` function encodes and decodes a UTF-8 string to and from a byte array.
+ *
+ * ```ts
+ * const bytes = getUtf8Codec().encode('hello'); // 0x68656c6c6f
+ * const value = getUtf8Codec().decode(bytes); // "hello"
+ * ```
+ *
+ * As usual, separate `getUtf8Encoder` and `getUtf8Decoder` functions are also available.
+ *
+ * ```ts
+ * const bytes = getUtf8Encoder().encode('hello'); // 0x68656c6c6f
+ * const value = getUtf8Decoder().decode(bytes); // "hello"
+ * ```
+ *
+ * ## Base 64 codec
+ *
+ * The `getBase64Codec` function encodes and decodes a base-64 string to and from a byte array.
+ *
+ * ```ts
+ * const bytes = getBase64Codec().encode('hello+world'); // 0x85e965a3ec28ae57
+ * const value = getBase64Codec().decode(bytes); // "hello+world"
+ * ```
+ *
+ * As usual, separate `getBase64Encoder` and `getBase64Decoder` functions are also available.
+ *
+ * ```ts
+ * const bytes = getBase64Encoder().encode('hello+world'); // 0x85e965a3ec28ae57
+ * const value = getBase64Decoder().decode(bytes); // "hello+world"
+ * ```
+ *
+ * ## Base 58 codec
+ *
+ * The `getBase58Codec` function encodes and decodes a base-58 string to and from a byte array.
+ *
+ * ```ts
+ * const bytes = getBase58Codec().encode('heLLo'); // 0x1b6a3070
+ * const value = getBase58Codec().decode(bytes); // "heLLo"
+ * ```
+ *
+ * As usual, separate `getBase58Encoder` and `getBase58Decoder` functions are also available.
+ *
+ * ```ts
+ * const bytes = getBase58Encoder().encode('heLLo'); // 0x1b6a3070
+ * const value = getBase58Decoder().decode(bytes); // "heLLo"
+ * ```
+ *
+ * ## Base 16 codec
+ *
+ * The `getBase16Codec` function encodes and decodes a base-16 string to and from a byte array.
+ *
+ * ```ts
+ * const bytes = getBase16Codec().encode('deadface'); // 0xdeadface
+ * const value = getBase16Codec().decode(bytes); // "deadface"
+ * ```
+ *
+ * As usual, separate `getBase16Encoder` and `getBase16Decoder` functions are also available.
+ *
+ * ```ts
+ * const bytes = getBase16Encoder().encode('deadface'); // 0xdeadface
+ * const value = getBase16Decoder().decode(bytes); // "deadface"
+ * ```
+ *
+ * ## Base 10 codec
+ *
+ * The `getBase10Codec` function encodes and decodes a base-10 string to and from a byte array.
+ *
+ * ```ts
+ * const bytes = getBase10Codec().encode('1024'); // 0x0400
+ * const value = getBase10Codec().decode(bytes); // "1024"
+ * ```
+ *
+ * As usual, separate `getBase10Encoder` and `getBase10Decoder` functions are also available.
+ *
+ * ```ts
+ * const bytes = getBase10Encoder().encode('1024'); // 0x0400
+ * const value = getBase10Decoder().decode(bytes); // "1024"
+ * ```
+ *
+ * ## Base X codec
+ *
+ * The `getBaseXCodec` accepts a custom `alphabet` of `X` characters and creates a base-X codec using that alphabet.
+ * It does so by iteratively dividing by `X` and handling leading zeros.
+ *
+ * The base-10 and base-58 codecs use this base-x codec under the hood.
+ *
+ * ```ts
+ * const alphabet = '0ehlo';
+ * const bytes = getBaseXCodec(alphabet).encode('hello'); // 0x05bd
+ * const value = getBaseXCodec(alphabet).decode(bytes); // "hello"
+ * ```
+ *
+ * As usual, separate `getBaseXEncoder` and `getBaseXDecoder` functions are also available.
+ *
+ * ```ts
+ * const bytes = getBaseXEncoder(alphabet).encode('hello'); // 0x05bd
+ * const value = getBaseXDecoder(alphabet).decode(bytes); // "hello"
+ * ```
+ *
+ * ## Re-slicing base X codec
+ *
+ * The `getBaseXResliceCodec` also creates a base-x codec but uses a different strategy.
+ * It re-slices bytes into custom chunks of bits that are then mapped to a provided `alphabet`.
+ * The number of bits per chunk is also provided and should typically be set to `log2(alphabet.length)`.
+ *
+ * This is typically used to create codecs whose alphabet’s length is a power of 2 such as base-16 or base-64.
+ *
+ * ```ts
+ * const bytes = getBaseXResliceCodec('elho', 2).encode('hellolol'); // 0x4aee
+ * const value = getBaseXResliceCodec('elho', 2).decode(bytes); // "hellolol"
+ * ```
+ *
+ * As usual, separate `getBaseXResliceEncoder` and `getBaseXResliceDecoder` functions are also available.
+ *
+ * ```ts
+ * const bytes = getBaseXResliceEncoder('elho', 2).encode('hellolol'); // 0x4aee
+ * const value = getBaseXResliceDecoder('elho', 2).decode(bytes); // "hellolol"
+ * ```
+ *
+ * @packageDocumentation
+ */
 export * from './assertions';
 export * from './base10';
 export * from './base16';

--- a/packages/codecs-strings/src/null-characters.ts
+++ b/packages/codecs-strings/src/null-characters.ts
@@ -1,7 +1,36 @@
-/**Removes null characters from a string. */
+/**
+ * Removes all null characters (`\u0000`) from a string.
+ *
+ * This function cleans a string by stripping out any null characters,
+ * which are often used as padding in fixed-size string encodings.
+ *
+ * @param value - The string to process.
+ * @returns The input string with all null characters removed.
+ *
+ * @example
+ * Removing null characters from a string.
+ * ```ts
+ * removeNullCharacters('hello\u0000\u0000'); // "hello"
+ * ```
+ */
 export const removeNullCharacters = (value: string) =>
     // eslint-disable-next-line no-control-regex
     value.replace(/\u0000/g, '');
 
-/** Pads a string with null characters at the end. */
+/**
+ * Pads a string with null characters (`\u0000`) at the end to reach a fixed length.
+ *
+ * If the input string is shorter than the specified length, it is padded with null characters
+ * until it reaches the desired size. If it is already long enough, it remains unchanged.
+ *
+ * @param value - The string to pad.
+ * @param chars - The total length of the resulting string, including padding.
+ * @returns The input string padded with null characters up to the specified length.
+ *
+ * @example
+ * Padding a string with null characters.
+ * ```ts
+ * padNullCharacters('hello', 8); // "hello\u0000\u0000\u0000"
+ * ```
+ */
 export const padNullCharacters = (value: string, chars: number) => value.padEnd(chars, '\u0000');

--- a/packages/codecs-strings/src/utf8.ts
+++ b/packages/codecs-strings/src/utf8.ts
@@ -10,7 +10,25 @@ import { TextDecoder, TextEncoder } from '@solana/text-encoding-impl';
 
 import { removeNullCharacters } from './null-characters';
 
-/** Encodes UTF-8 strings using the native `TextEncoder` API. */
+/**
+ * Returns an encoder for UTF-8 strings.
+ *
+ * This encoder serializes strings using UTF-8 encoding.
+ * The encoded output contains as many bytes as needed to represent the string.
+ *
+ * For more details, see {@link getUtf8Codec}.
+ *
+ * @returns A `VariableSizeEncoder<string>` for encoding UTF-8 strings.
+ *
+ * @example
+ * Encoding a UTF-8 string.
+ * ```ts
+ * const encoder = getUtf8Encoder();
+ * const bytes = encoder.encode('hello'); // 0x68656c6c6f
+ * ```
+ *
+ * @see {@link getUtf8Codec}
+ */
 export const getUtf8Encoder = (): VariableSizeEncoder<string> => {
     let textEncoder: TextEncoder;
     return createEncoder({
@@ -23,7 +41,25 @@ export const getUtf8Encoder = (): VariableSizeEncoder<string> => {
     });
 };
 
-/** Decodes UTF-8 strings using the native `TextDecoder` API. */
+/**
+ * Returns a decoder for UTF-8 strings.
+ *
+ * This decoder deserializes UTF-8 encoded strings from a byte array.
+ * It reads all available bytes starting from the given offset.
+ *
+ * For more details, see {@link getUtf8Codec}.
+ *
+ * @returns A `VariableSizeDecoder<string>` for decoding UTF-8 strings.
+ *
+ * @example
+ * Decoding a UTF-8 string.
+ * ```ts
+ * const decoder = getUtf8Decoder();
+ * const value = decoder.decode(new Uint8Array([0x68, 0x65, 0x6c, 0x6c, 0x6f])); // "hello"
+ * ```
+ *
+ * @see {@link getUtf8Codec}
+ */
 export const getUtf8Decoder = (): VariableSizeDecoder<string> => {
     let textDecoder: TextDecoder;
     return createDecoder({
@@ -34,5 +70,45 @@ export const getUtf8Decoder = (): VariableSizeDecoder<string> => {
     });
 };
 
-/** Encodes and decodes UTF-8 strings using the native `TextEncoder` and `TextDecoder` API. */
+/**
+ * Returns a codec for encoding and decoding UTF-8 strings.
+ *
+ * This codec serializes strings using UTF-8 encoding.
+ * The encoded output contains as many bytes as needed to represent the string.
+ *
+ * @returns A `VariableSizeCodec<string>` for encoding and decoding UTF-8 strings.
+ *
+ * @example
+ * Encoding and decoding a UTF-8 string.
+ * ```ts
+ * const codec = getUtf8Codec();
+ * const bytes = codec.encode('hello'); // 0x68656c6c6f
+ * const value = codec.decode(bytes);   // "hello"
+ * ```
+ *
+ * @remarks
+ * This codec does not enforce a size boundary. It will encode and decode all bytes necessary to represent the string.
+ *
+ * If you need a fixed-size UTF-8 codec, consider using {@link fixCodecSize}.
+ *
+ * ```ts
+ * const codec = fixCodecSize(getUtf8Codec(), 5);
+ * ```
+ *
+ * If you need a size-prefixed UTF-8 codec, consider using {@link addCodecSizePrefix}.
+ *
+ * ```ts
+ * const codec = addCodecSizePrefix(getUtf8Codec(), getU32Codec());
+ * ```
+ *
+ * Separate {@link getUtf8Encoder} and {@link getUtf8Decoder} functions are available.
+ *
+ * ```ts
+ * const bytes = getUtf8Encoder().encode('hello');
+ * const value = getUtf8Decoder().decode(bytes);
+ * ```
+ *
+ * @see {@link getUtf8Encoder}
+ * @see {@link getUtf8Decoder}
+ */
 export const getUtf8Codec = (): VariableSizeCodec<string> => combineCodec(getUtf8Encoder(), getUtf8Decoder());

--- a/packages/codecs-strings/typedoc.json
+++ b/packages/codecs-strings/typedoc.json
@@ -1,5 +1,6 @@
 {
     "$schema": "https://typedoc.org/schema.json",
     "extends": ["../typedoc.base.json"],
-    "entryPoints": ["src/index.ts"]
+    "entryPoints": ["src/index.ts"],
+    "readme": "none"
 }


### PR DESCRIPTION
This PR adds TypeDoc-compatible docblocks to all items inside the `codecs-data-structures` package.

Addresses #50

# Test Plan

```shell
cd packages/codecs-data-structures
pnpm typedoc --watch --plugin typedoc-plugin-missing-exports
python3 -m http.server -d docs
```

Preview here: https://fascinating-genie-cd6351.netlify.app/