### PR TITLE
[fix] return signature for send and confirm factories

### DIFF
--- a/.changeset/silver-pianos-dress.md
+++ b/.changeset/silver-pianos-dress.md
@@ -1,0 +1,5 @@
+---
+'@solana/web3.js': patch
+---
+
+return the transaction signature from the `sendAndConfirmTransactionFactory` and `sendAndConfirmDurableNonceTransactionFactory` since they already have the signature avaialble

--- a/packages/library/src/send-and-confirm-durable-nonce-transaction.ts
+++ b/packages/library/src/send-and-confirm-durable-nonce-transaction.ts
@@ -8,6 +8,7 @@ import {
 import { FullySignedTransaction, TransactionWithDurableNonceLifetime } from '@solana/transactions';
 
 import { sendAndConfirmDurableNonceTransaction_INTERNAL_ONLY_DO_NOT_EXPORT } from './send-transaction-internal';
+import type { Signature } from '@solana/keys';
 
 type SendAndConfirmDurableNonceTransactionFunction = (
     transaction: FullySignedTransaction & TransactionWithDurableNonceLifetime,
@@ -15,7 +16,7 @@ type SendAndConfirmDurableNonceTransactionFunction = (
         Parameters<typeof sendAndConfirmDurableNonceTransaction_INTERNAL_ONLY_DO_NOT_EXPORT>[0],
         'confirmDurableNonceTransaction' | 'rpc' | 'transaction'
     >,
-) => Promise<void>;
+) => Promise<Signature>;
 
 type SendAndConfirmDurableNonceTransactionFactoryConfig<TCluster> = {
     rpc: Rpc<GetAccountInfoApi & GetSignatureStatusesApi & SendTransactionApi> & { '~cluster'?: TCluster };
@@ -60,7 +61,7 @@ export function sendAndConfirmDurableNonceTransactionFactory<
         });
     }
     return async function sendAndConfirmDurableNonceTransaction(transaction, config) {
-        await sendAndConfirmDurableNonceTransaction_INTERNAL_ONLY_DO_NOT_EXPORT({
+        return await sendAndConfirmDurableNonceTransaction_INTERNAL_ONLY_DO_NOT_EXPORT({
             ...config,
             confirmDurableNonceTransaction,
             rpc,

--- a/packages/library/src/send-and-confirm-durable-nonce-transaction.ts
+++ b/packages/library/src/send-and-confirm-durable-nonce-transaction.ts
@@ -1,3 +1,4 @@
+import type { Signature } from '@solana/keys';
 import type { GetAccountInfoApi, GetSignatureStatusesApi, Rpc, SendTransactionApi } from '@solana/rpc';
 import type { AccountNotificationsApi, RpcSubscriptions, SignatureNotificationsApi } from '@solana/rpc-subscriptions';
 import {
@@ -8,7 +9,6 @@ import {
 import { FullySignedTransaction, TransactionWithDurableNonceLifetime } from '@solana/transactions';
 
 import { sendAndConfirmDurableNonceTransaction_INTERNAL_ONLY_DO_NOT_EXPORT } from './send-transaction-internal';
-import type { Signature } from '@solana/keys';
 
 type SendAndConfirmDurableNonceTransactionFunction = (
     transaction: FullySignedTransaction & TransactionWithDurableNonceLifetime,

--- a/packages/library/src/send-and-confirm-transaction.ts
+++ b/packages/library/src/send-and-confirm-transaction.ts
@@ -1,3 +1,4 @@
+import type { Signature } from '@solana/keys';
 import type { GetEpochInfoApi, GetSignatureStatusesApi, Rpc, SendTransactionApi } from '@solana/rpc';
 import type { RpcSubscriptions, SignatureNotificationsApi, SlotNotificationsApi } from '@solana/rpc-subscriptions';
 import {
@@ -8,7 +9,6 @@ import {
 import { FullySignedTransaction, TransactionWithBlockhashLifetime } from '@solana/transactions';
 
 import { sendAndConfirmTransactionWithBlockhashLifetime_INTERNAL_ONLY_DO_NOT_EXPORT } from './send-transaction-internal';
-import type { Signature } from '@solana/keys';
 
 type SendAndConfirmTransactionWithBlockhashLifetimeFunction = (
     transaction: FullySignedTransaction & TransactionWithBlockhashLifetime,

--- a/packages/library/src/send-and-confirm-transaction.ts
+++ b/packages/library/src/send-and-confirm-transaction.ts
@@ -8,6 +8,7 @@ import {
 import { FullySignedTransaction, TransactionWithBlockhashLifetime } from '@solana/transactions';
 
 import { sendAndConfirmTransactionWithBlockhashLifetime_INTERNAL_ONLY_DO_NOT_EXPORT } from './send-transaction-internal';
+import type { Signature } from '@solana/keys';
 
 type SendAndConfirmTransactionWithBlockhashLifetimeFunction = (
     transaction: FullySignedTransaction & TransactionWithBlockhashLifetime,
@@ -15,7 +16,7 @@ type SendAndConfirmTransactionWithBlockhashLifetimeFunction = (
         Parameters<typeof sendAndConfirmTransactionWithBlockhashLifetime_INTERNAL_ONLY_DO_NOT_EXPORT>[0],
         'confirmRecentTransaction' | 'rpc' | 'transaction'
     >,
-) => Promise<void>;
+) => Promise<Signature>;
 
 type SendAndConfirmTransactionWithBlockhashLifetimeFactoryConfig<TCluster> = {
     rpc: Rpc<GetEpochInfoApi & GetSignatureStatusesApi & SendTransactionApi> & { '~cluster'?: TCluster };
@@ -59,7 +60,7 @@ export function sendAndConfirmTransactionFactory<TCluster extends 'devnet' | 'ma
         });
     }
     return async function sendAndConfirmTransaction(transaction, config) {
-        await sendAndConfirmTransactionWithBlockhashLifetime_INTERNAL_ONLY_DO_NOT_EXPORT({
+        return await sendAndConfirmTransactionWithBlockhashLifetime_INTERNAL_ONLY_DO_NOT_EXPORT({
             ...config,
             confirmRecentTransaction,
             rpc,


### PR DESCRIPTION
#### Problem

The `sendAndConfirmDurableNonceTransactionFactory` and `sendAndConfirmTransactionFactory` factories return a `Promise<void>` while the underlying `sendTransaction_INTERNAL_ONLY_DO_NOT_EXPORT` returns a `Promise<Signature>`

#### Summary of Changes

Fix the return type of both factories to return the signature that they already have due to just confirming it.

`sendTransaction_INTERNAL_ONLY_DO_NOT_EXPORT` already imports the `Signature` type so this does not add a new dep