### PR TITLE
Add `getPublicKeyFromAddress` to derive public keys from addresses

### DIFF
--- a/.changeset/honest-plums-approve.md
+++ b/.changeset/honest-plums-approve.md
@@ -1,0 +1,5 @@
+---
+'@solana/addresses': minor
+---
+
+Add getPublicKeyFromAddress to derive public keys from addresses

--- a/packages/addresses/src/__tests__/public-key-test.ts
+++ b/packages/addresses/src/__tests__/public-key-test.ts
@@ -1,4 +1,7 @@
-import { getAddressFromPublicKey } from '../public-key';
+import { SOLANA_ERROR__ADDRESSES__STRING_LENGTH_OUT_OF_RANGE, SolanaError } from '@solana/errors';
+
+import { address } from '../address';
+import { getAddressFromPublicKey, getPublicKeyFromAddress } from '../public-key';
 
 // Corresponds to address `DcESq8KFcdTdpjWtr2DoGcvu5McM3VJoBetgM1X1vVct`
 const MOCK_PUBLIC_KEY_BYTES = new Uint8Array([
@@ -80,5 +83,24 @@ describe('getAddressFromPublicKey', () => {
             ['sign'],
         );
         await expect(() => getAddressFromPublicKey(mockPrivateKey)).rejects.toThrow();
+    });
+});
+
+describe('getPublicKeyFromAddress', () => {
+    it('returns the public key that corresponds to a given address', async () => {
+        expect.assertions(1);
+        const publicKey = await getPublicKeyFromAddress(address('DcESq8KFcdTdpjWtr2DoGcvu5McM3VJoBetgM1X1vVct'), true);
+        expect(new Uint8Array(await crypto.subtle.exportKey('raw', publicKey))).toEqual(MOCK_PUBLIC_KEY_BYTES);
+    });
+
+    it('throws when it is called with an invalid address', async () => {
+        expect.assertions(1);
+        await expect(
+            async () => await getPublicKeyFromAddress(address('not-a-base-58-encoded-string'), true),
+        ).rejects.toThrow(
+            new SolanaError(SOLANA_ERROR__ADDRESSES__STRING_LENGTH_OUT_OF_RANGE, {
+                actualLength: 28,
+            }),
+        );
     });
 });

--- a/packages/addresses/src/__tests__/public-key-test.ts
+++ b/packages/addresses/src/__tests__/public-key-test.ts
@@ -1,5 +1,3 @@
-import { SOLANA_ERROR__ADDRESSES__STRING_LENGTH_OUT_OF_RANGE, SolanaError } from '@solana/errors';
-
 import { address } from '../address';
 import { getAddressFromPublicKey, getPublicKeyFromAddress } from '../public-key';
 
@@ -89,18 +87,7 @@ describe('getAddressFromPublicKey', () => {
 describe('getPublicKeyFromAddress', () => {
     it('returns the public key that corresponds to a given address', async () => {
         expect.assertions(1);
-        const publicKey = await getPublicKeyFromAddress(address('DcESq8KFcdTdpjWtr2DoGcvu5McM3VJoBetgM1X1vVct'), true);
+        const publicKey = await getPublicKeyFromAddress(address('DcESq8KFcdTdpjWtr2DoGcvu5McM3VJoBetgM1X1vVct'));
         expect(new Uint8Array(await crypto.subtle.exportKey('raw', publicKey))).toEqual(MOCK_PUBLIC_KEY_BYTES);
-    });
-
-    it('throws when it is called with an invalid address', async () => {
-        expect.assertions(1);
-        await expect(
-            async () => await getPublicKeyFromAddress(address('not-a-base-58-encoded-string'), true),
-        ).rejects.toThrow(
-            new SolanaError(SOLANA_ERROR__ADDRESSES__STRING_LENGTH_OUT_OF_RANGE, {
-                actualLength: 28,
-            }),
-        );
     });
 });

--- a/packages/addresses/src/public-key.ts
+++ b/packages/addresses/src/public-key.ts
@@ -1,7 +1,7 @@
 import { assertKeyExporterIsAvailable } from '@solana/assertions';
 import { SOLANA_ERROR__ADDRESSES__INVALID_ED25519_PUBLIC_KEY, SolanaError } from '@solana/errors';
 
-import { Address, assertIsAddress, getAddressDecoder, getAddressEncoder } from './address';
+import { Address, getAddressDecoder, getAddressEncoder } from './address';
 
 /**
  * Given a public {@link CryptoKey}, this method will return its associated {@link Address}.
@@ -32,9 +32,7 @@ export async function getAddressFromPublicKey(publicKey: CryptoKey): Promise<Add
  * const publicKey = await getPublicKeyFromAddress(address);
  * ```
  */
-export async function getPublicKeyFromAddress(address: Address, extractable: boolean = false) {
-    assertIsAddress(address);
+export async function getPublicKeyFromAddress(address: Address) {
     const addressBytes = getAddressEncoder().encode(address);
-
-    return await crypto.subtle.importKey('raw', addressBytes, { name: 'Ed25519' }, extractable, ['verify']);
+    return await crypto.subtle.importKey('raw', addressBytes, { name: 'Ed25519' }, true /* extractable */, ['verify']);
 }

--- a/packages/addresses/src/public-key.ts
+++ b/packages/addresses/src/public-key.ts
@@ -1,7 +1,7 @@
-import {assertKeyExporterIsAvailable} from '@solana/assertions';
-import {SOLANA_ERROR__ADDRESSES__INVALID_ED25519_PUBLIC_KEY, SolanaError} from '@solana/errors';
+import { assertKeyExporterIsAvailable } from '@solana/assertions';
+import { SOLANA_ERROR__ADDRESSES__INVALID_ED25519_PUBLIC_KEY, SolanaError } from '@solana/errors';
 
-import {Address, assertIsAddress, getAddressDecoder, getAddressEncoder} from './address';
+import { Address, assertIsAddress, getAddressDecoder, getAddressEncoder } from './address';
 
 /**
  * Given a public {@link CryptoKey}, this method will return its associated {@link Address}.

--- a/packages/addresses/src/public-key.ts
+++ b/packages/addresses/src/public-key.ts
@@ -1,7 +1,7 @@
-import { assertKeyExporterIsAvailable } from '@solana/assertions';
-import { SOLANA_ERROR__ADDRESSES__INVALID_ED25519_PUBLIC_KEY, SolanaError } from '@solana/errors';
+import {assertKeyExporterIsAvailable} from '@solana/assertions';
+import {SOLANA_ERROR__ADDRESSES__INVALID_ED25519_PUBLIC_KEY, SolanaError} from '@solana/errors';
 
-import { Address, getAddressDecoder } from './address';
+import {Address, assertIsAddress, getAddressDecoder, getAddressEncoder} from './address';
 
 /**
  * Given a public {@link CryptoKey}, this method will return its associated {@link Address}.
@@ -20,4 +20,21 @@ export async function getAddressFromPublicKey(publicKey: CryptoKey): Promise<Add
     }
     const publicKeyBytes = await crypto.subtle.exportKey('raw', publicKey);
     return getAddressDecoder().decode(new Uint8Array(publicKeyBytes));
+}
+
+/**
+ * Given an {@link Address}, return a {@link CryptoKey} that can be used to verify signatures.
+ *
+ * @example
+ * ```ts
+ * import { getAddressFromPublicKey } from '@solana/addresses';
+ *
+ * const publicKey = await getPublicKeyFromAddress(address);
+ * ```
+ */
+export async function getPublicKeyFromAddress(address: Address, extractable: boolean = false) {
+    assertIsAddress(address);
+    const addressBytes = getAddressEncoder().encode(address);
+
+    return await crypto.subtle.importKey('raw', addressBytes, { name: 'Ed25519' }, extractable, ['verify']);
 }


### PR DESCRIPTION
This commit introduces `getPublicKeyFromAddress`, which allows deriving a `CryptoKey` from a given Solana address. This is useful for verifying signatures when only the address is available.

#### Problem
There is no convenient way to derive a `CryptoKey` from an `Address`.

#### Summary of Changes
 - Adds `getPublicKeyFromAddress` to `public-key.ts`
 - Ensures the function properly asserts valid addresses before decoding
 - Updates tests to check valid and invalid address handling
 - Uses `crypto.subtle.importKey` to create an Ed25519 verification key

Fixes #

https://solana.stackexchange.com/questions/18940/how-to-convert-address-to-pubkey-in-solana-web3-js-v2