### PR TITLE
Use Graphite's ‘dismiss stale reviews’ action

### DIFF
--- a/.github/workflows/dismiss-stale-pr-reviews.yml
+++ b/.github/workflows/dismiss-stale-pr-reviews.yml
@@ -1,0 +1,24 @@
+name: Dismiss stale pull request approvals
+
+on:
+  pull_request:
+    types: [
+        opened,
+        synchronize,
+        reopened,
+      ]
+
+
+permissions:
+  actions: read
+  contents: read
+  pull-requests: write
+
+jobs:
+  dismiss_stale_approvals:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Dismiss stale pull request approvals
+        uses: withgraphite/dismiss-stale-approvals@main
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/dismiss-stale-pr-reviews.yml
+++ b/.github/workflows/dismiss-stale-pr-reviews.yml
@@ -1,4 +1,4 @@
-name: Dismiss stale pull request approvals
+name: Dismiss Stale PR Reviews
 
 on:
   pull_request:
@@ -18,7 +18,7 @@ jobs:
   dismiss_stale_approvals:
     runs-on: ubuntu-latest
     steps:
-      - name: Dismiss stale pull request approvals
+      - name: Dismiss Stale PR Reviews
         uses: withgraphite/dismiss-stale-approvals@main
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
#### Problem

The stock GitHub ‘dismiss review on changes’ doesn't consider the actual diff when dismissing reviews. It dismisses reviews on operations as simple as rebasing.

#### Summary of Changes

Add Graphite's custom action for this purpose.

From their support folks:

> We've recently created an open source GitHub Action meant to serve as a drop-in replacement for the "Dismiss stale reviews" protection.
> 
> It tracks the diff of each push to the PR and uses `git range-diff` to only dismiss reviews when the diff itself has changed, thus avoiding dismissing reviews for the simple (i.e. direct cherry-pick) rebases that our merge orchestration performs.
>
> - We made it as simple as possible and fully open source in order to satisfy the curiosity of any security/compliance folks who would like to verify that it does what it says on the tin.
> - If the parsing/checks fail for any reason, it "fails open", defaulting to dismissing reviews. 
> - It can be made required, thus ensuring that the PR cannot be merged until it has run.
