### PR TITLE
Update publish packages workflow to create GitHub Releases

### DIFF
--- a/.github/workflows/publish-packages.yml
+++ b/.github/workflows/publish-packages.yml
@@ -39,20 +39,16 @@ jobs:
         env:
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
 
-      - name: Create Changesets Pull Request or Trigger an NPM Publish
+      - name: Build And Test (bypass cache)
+        run: pnpm build --force
+
+      - name: Create Changesets Pull Request or Publish to NPM
         id: changesets
         uses: changesets/action@v1
+        with:
+          publish: pnpm turbo publish-packages --concurrency=${TURBO_CONCURRENCY:-1}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Choose Build Step
-        id: build-step-decider
-        run: echo "step-name=${{ steps.changesets.outputs.hasChangesets == 'false' && 'publish-packages --concurrency=${TURBO_CONCURRENCY:-1}' || 'build' }}" >> $GITHUB_OUTPUT
-
-      - name: Run Build Step (force)
-        run: pnpm turbo ${{ steps.build-step-decider.outputs.step-name }} --force=true
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
           PUBLISH_TAG: next
 

--- a/turbo.json
+++ b/turbo.json
@@ -30,7 +30,6 @@
             "outputs": ["dist/**/*.d.ts"]
         },
         "publish-packages": {
-            "cache": false,
             "dependsOn": [
                 "compile:js",
                 "compile:typedefs",


### PR DESCRIPTION
#### Problem

Currently, the publish workflow is set up to do the following

- Create a versioning PR if appropriate
- See if there are pending changesets
  - Publish to NPM if there are not
  - Just do a build if there are

Notably, because the first step abdicates the responsibility of publishing to the second step, no GitHub Release will ever be published.

#### Summary of Changes

- Build and test unconditionally, bypassing the cache
- Allow the `publish-packages` GitHub step to use that cache
- Allow the `changesets/action` to _actually_ do the publish, and by implication the GitHub Release.
