### PR TITLE
Upgrade `feePayer` to a signer when using `addSignersToTransactionMessage`

### DIFF
--- a/.changeset/breezy-poems-wonder.md
+++ b/.changeset/breezy-poems-wonder.md
@@ -1,0 +1,5 @@
+---
+'@solana/signers': patch
+---
+
+`addSignersToTransactionMessage` now upgrades `feePayer` to a signer when applicable

--- a/packages/signers/README.md
+++ b/packages/signers/README.md
@@ -507,7 +507,7 @@ const myInstructionWithSigners = addSignersToInstruction([mySignerA, mySignerB],
 
 #### `addSignersToTransactionMessage()`
 
-Similarly to `addSignersToInstruction`, this function adds signer to all the applicable account metas of all the instructions inside a transaction message.
+Similarly to `addSignersToInstruction`, this function adds signer to all the applicable account metas of all the instructions inside a transaction message. Note that it also updates the fee payer if necessary.
 
 ```ts
 const myTransactionMessageWithSigners = addSignersToTransactionMessage(mySigners, myTransactionMessage);

--- a/packages/signers/src/__typetests__/add-signers-typetest.ts
+++ b/packages/signers/src/__typetests__/add-signers-typetest.ts
@@ -1,0 +1,30 @@
+import { IInstruction } from '@solana/instructions';
+import { TransactionMessage } from '@solana/transaction-messages';
+
+import { IInstructionWithSigners, ITransactionMessageWithSigners } from '../account-signer-meta';
+import { addSignersToInstruction, addSignersToTransactionMessage } from '../add-signers';
+import { TransactionSigner } from '../transaction-signer';
+
+const aliceSigner = null as unknown as TransactionSigner<'alice'>;
+const bobSigner = null as unknown as TransactionSigner<'bob'>;
+
+const instruction = null as unknown as IInstruction;
+const message = null as unknown as TransactionMessage;
+
+// [DESCRIBE] addSignersToInstruction
+{
+    // It adds the `WithSigners` type expansion to the instruction
+    {
+        const instructionWithSigners = addSignersToInstruction([aliceSigner, bobSigner], instruction);
+        instructionWithSigners satisfies IInstructionWithSigners;
+    }
+}
+
+// [DESCRIBE] addSignersToTransactionMessage
+{
+    // It adds the `WithSigners` type expansion to the transaction message
+    {
+        const messageWithSigners = addSignersToTransactionMessage([aliceSigner, bobSigner], message);
+        messageWithSigners satisfies ITransactionMessageWithSigners;
+    }
+}


### PR DESCRIPTION
This PR upgrades the `feePayer` attribute of a transaction message if and only if:
- The current `feePayer` attribute is set.
- The current `feePayer` attribute is not already a signer (i.e. address only).
- The current `feePayer` address matches one of the provided signers.

Note that the `addSignersToTransactionMessage` does not narrow the returned transaction message with a `ITransactionMessageWithFeePayerSigner` because this may or may not happen based on the provided signers. If desired, we could iterate over the explicit `TransactionSigner<TAddress>` array to figure out at compile time if we need to return a `ITransactionMessageWithFeePayerSigner` type. This felt like an overkill and over-complication of the types to me but happy to disagree and commit.

Fixes #82