### PR TITLE
Correct `RewardType` enum values

### DIFF
--- a/.changeset/shaggy-candles-tell.md
+++ b/.changeset/shaggy-candles-tell.md
@@ -1,0 +1,6 @@
+---
+'@solana/rpc-graphql': patch
+'@solana/rpc-types': patch
+---
+
+The values of the `rewardType` property have been corrected. They previously were specified as having a lowercase initial character.

--- a/packages/rpc-graphql/README.md
+++ b/packages/rpc-graphql/README.md
@@ -906,12 +906,12 @@ data: {
             {
                 commission: 0.05,
                 lamports: 58578n,
-                rewardType: 'staking',
+                rewardType: 'Staking',
             },
             {
                 commission: 0.05,
                 lamports: 58578n,
-                rewardType: 'staking',
+                rewardType: 'Staking',
             }
         ],
         transactions: [

--- a/packages/rpc-graphql/src/__tests__/__setup__.ts
+++ b/packages/rpc-graphql/src/__tests__/__setup__.ts
@@ -2960,21 +2960,21 @@ const mockRewards = [
         lamports: 50000,
         postBalance: 1000000000000000,
         pubkey: 'DdNzYKnkq7PqCRX4kncvwVYNZE7dZ9xdCz6yMekqjWH4',
-        rewardType: 'stake',
+        rewardType: 'Staking',
     },
     {
         commission: 0.1,
         lamports: 50000,
         postBalance: 1000000000000000,
         pubkey: 'DdNzYKnkq7PqCRX4kncvwVYNZE7dZ9xdCz6yMekqjWH4',
-        rewardType: 'stake',
+        rewardType: 'Staking',
     },
     {
         commission: 0.1,
         lamports: 50000,
         postBalance: 1000000000000000,
         pubkey: 'DdNzYKnkq7PqCRX4kncvwVYNZE7dZ9xdCz6yMekqjWH4',
-        rewardType: 'stake',
+        rewardType: 'Staking',
     },
 ];
 

--- a/packages/rpc-types/src/transaction.ts
+++ b/packages/rpc-types/src/transaction.ts
@@ -308,7 +308,7 @@ type RewardBase = Readonly<{
 export type Reward =
     | (Readonly<{
           /** type of reward */
-          rewardType: 'fee' | 'rent';
+          rewardType: 'Fee' | 'Rent';
       }> &
           RewardBase)
     /** Commission is present only for voting and staking rewards */
@@ -316,7 +316,7 @@ export type Reward =
           /** vote account commission when the reward was credited */
           commission: number;
           /** type of reward */
-          rewardType: 'staking' | 'voting';
+          rewardType: 'Staking' | 'Voting';
       }> &
           RewardBase);
 


### PR DESCRIPTION
See https://github.com/anza-xyz/agave/blob/64a88714b18c300ce6b5f7d08de7c89fafdb9e8b/storage-proto/proto/confirmed_block.proto#L116-L122.

Fixes #141
